### PR TITLE
Support Soundcloud likes in channel and feed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -214,7 +214,7 @@ dependencies {
     // the corresponding commit hash, since JitPack sometimes deletes artifacts.
     // If there’s already a git hash, just add more of it to the end (or remove a letter)
     // to cause jitpack to regenerate the artifact.
-    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.6'
+    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.7'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -214,7 +214,7 @@ dependencies {
     // the corresponding commit hash, since JitPack sometimes deletes artifacts.
     // If there’s already a git hash, just add more of it to the end (or remove a letter)
     // to cause jitpack to regenerate the artifact.
-    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.7'
+    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:71b335128e8b66ecc0cd45379dd11a0865973065'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
@@ -24,6 +24,7 @@ public final class ChannelTabHelper {
         switch (tab) {
             case ChannelTabs.VIDEOS:
             case ChannelTabs.TRACKS:
+            case ChannelTabs.LIKES:
             case ChannelTabs.SHORTS:
             case ChannelTabs.LIVESTREAMS:
                 return true;
@@ -62,6 +63,8 @@ public final class ChannelTabHelper {
                 return R.string.show_channel_tabs_playlists;
             case ChannelTabs.ALBUMS:
                 return R.string.show_channel_tabs_albums;
+            case ChannelTabs.LIKES:
+                return R.string.show_channel_tabs_likes;
             default:
                 return -1;
         }
@@ -78,6 +81,8 @@ public final class ChannelTabHelper {
                 return R.string.fetch_channel_tabs_shorts;
             case ChannelTabs.LIVESTREAMS:
                 return R.string.fetch_channel_tabs_livestreams;
+            case ChannelTabs.LIKES:
+                return R.string.fetch_channel_tabs_likes;
             default:
                 return -1;
         }
@@ -100,6 +105,8 @@ public final class ChannelTabHelper {
                 return R.string.channel_tab_playlists;
             case ChannelTabs.ALBUMS:
                 return R.string.channel_tab_albums;
+            case ChannelTabs.LIKES:
+                return R.string.channel_tab_likes;
             default:
                 return R.string.unknown_content;
         }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -294,6 +294,7 @@
     <string name="show_channel_tabs_channels">show_channel_tabs_channels</string>
     <string name="show_channel_tabs_playlists">show_channel_tabs_playlists</string>
     <string name="show_channel_tabs_albums">show_channel_tabs_albums</string>
+    <string name="show_channel_tabs_likes">show_channel_tabs_likes</string>
     <string name="show_channel_tabs_about">show_channel_tabs_about</string>
     <string-array name="show_channel_tabs_value_list">
         <item>@string/show_channel_tabs_videos</item>
@@ -303,6 +304,7 @@
         <item>@string/show_channel_tabs_channels</item>
         <item>@string/show_channel_tabs_playlists</item>
         <item>@string/show_channel_tabs_albums</item>
+        <item>@string/show_channel_tabs_likes</item>
         <item>@string/show_channel_tabs_about</item>
     </string-array>
     <string-array name="show_channel_tabs_description_list">
@@ -313,6 +315,7 @@
         <item>@string/channel_tab_channels</item>
         <item>@string/channel_tab_playlists</item>
         <item>@string/channel_tab_albums</item>
+        <item>@string/channel_tab_likes</item>
         <item>@string/channel_tab_about</item>
     </string-array>
     <string name="show_search_suggestions_key">show_search_suggestions</string>
@@ -390,17 +393,20 @@
     <string name="fetch_channel_tabs_tracks">fetch_channel_tabs_tracks</string>
     <string name="fetch_channel_tabs_shorts">fetch_channel_tabs_shorts</string>
     <string name="fetch_channel_tabs_livestreams">fetch_channel_tabs_livestreams</string>
+    <string name="fetch_channel_tabs_likes">fetch_channel_tabs_likes</string>
     <string-array name="feed_fetch_channel_tabs_value_list">
         <item>@string/fetch_channel_tabs_videos</item>
         <item>@string/fetch_channel_tabs_tracks</item>
         <item>@string/fetch_channel_tabs_shorts</item>
         <item>@string/fetch_channel_tabs_livestreams</item>
+        <item>@string/fetch_channel_tabs_likes</item>
     </string-array>
     <string-array name="feed_fetch_channel_tabs_description_list">
         <item>@string/channel_tab_videos</item>
         <item>@string/channel_tab_tracks</item>
         <item>@string/channel_tab_shorts</item>
         <item>@string/channel_tab_livestreams</item>
+        <item>@string/channel_tab_likes</item>
     </string-array>
 
     <string name="import_export_data_path">import_export_data_path</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -828,6 +828,7 @@
     <string name="channel_tab_channels">Channels</string>
     <string name="channel_tab_playlists">Playlists</string>
     <string name="channel_tab_albums">Albums</string>
+    <string name="channel_tab_likes">Likes</string>
     <string name="channel_tab_about">About</string>
     <string name="show_channel_tabs">Channel tabs</string>
     <string name="show_channel_tabs_summary">What tabs are shown on the channel pages</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
 Add support for importing Soundcloud likes as a new tab before About in a user's channel.
The likes are also retrieved in the feed if the user is subscribed to.
#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
