### PR TITLE
Fix clearing queue when tapping on timestamp merge fix-timestamp-queue-reset branch to froyo for testing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1156,8 +1156,11 @@ public final class VideoDetailFragment
         final PlayQueue queue = setupPlayQueueForIntent(false);
         tryAddVideoPlayerView();
 
-        final Intent playerIntent = NavigationHelper.getPlayerIntent(requireContext(),
-                PlayerService.class, queue, true, autoPlayEnabled);
+        final Context context = requireContext();
+        final Intent playerIntent =
+                NavigationHelper.getPlayerIntent(context, PlayerService.class, queue)
+                        .putExtra(Player.PLAY_WHEN_READY, autoPlayEnabled)
+                        .putExtra(Player.RESUME_PLAYBACK, true);
         ContextCompat.startForegroundService(activity, playerIntent);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -93,6 +93,7 @@ import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.local.playlist.LocalPlaylistFragment;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.PlayerIntentType;
 import org.schabi.newpipe.player.PlayerService;
 import org.schabi.newpipe.player.PlayerType;
 import org.schabi.newpipe.player.event.OnKeyDownListener;
@@ -1158,7 +1159,8 @@ public final class VideoDetailFragment
 
         final Context context = requireContext();
         final Intent playerIntent =
-                NavigationHelper.getPlayerIntent(context, PlayerService.class, queue)
+                NavigationHelper.getPlayerIntent(context, PlayerService.class, queue,
+                                PlayerIntentType.AllOthers)
                         .putExtra(Player.PLAY_WHEN_READY, autoPlayEnabled)
                         .putExtra(Player.RESUME_PLAYBACK, true);
         ContextCompat.startForegroundService(activity, playerIntent);

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -357,15 +357,20 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         // Resolve enqueue intents
-        if (intent.getBooleanExtra(ENQUEUE, false) && playQueue != null) {
-            playQueue.append(newQueue.getStreams());
+        if (intent.getBooleanExtra(ENQUEUE, false)) {
+            if (playQueue != null) {
+                playQueue.append(newQueue.getStreams());
+            }
             return;
+        }
 
         // Resolve enqueue next intents
-        } else if (intent.getBooleanExtra(ENQUEUE_NEXT, false) && playQueue != null) {
-            final int currentIndex = playQueue.getIndex();
-            playQueue.append(newQueue.getStreams());
-            playQueue.move(playQueue.size() - 1, currentIndex + 1);
+        if (intent.getBooleanExtra(ENQUEUE_NEXT, false)) {
+            if (playQueue != null) {
+                final int currentIndex = playQueue.getIndex();
+                playQueue.append(newQueue.getStreams());
+                playQueue.move(playQueue.size() - 1, currentIndex + 1);
+            }
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -160,7 +160,6 @@ public final class Player implements PlaybackListener, Listener {
     public static final String RESUME_PLAYBACK = "resume_playback";
     public static final String PLAY_WHEN_READY = "play_when_ready";
     public static final String PLAYER_TYPE = "player_type";
-    public static final String IS_MUTED = "is_muted";
 
     /*//////////////////////////////////////////////////////////////////////////
     // Time constants
@@ -378,7 +377,6 @@ public final class Player implements PlaybackListener, Listener {
         final boolean samePlayQueue = playQueue != null && playQueue.equalStreamsAndIndex(newQueue);
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
-        final boolean isMuted = intent.getBooleanExtra(IS_MUTED, isMuted());
 
         /*
          * TODO As seen in #7427 this does not work:
@@ -436,7 +434,7 @@ public final class Player implements PlaybackListener, Listener {
                                             state.getProgressMillis());
                                 }
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted);
+                                        playbackSkipSilence, playWhenReady);
                             },
                             error -> {
                                 if (DEBUG) {
@@ -444,19 +442,19 @@ public final class Player implements PlaybackListener, Listener {
                                 }
                                 // In case any error we can start playback without history
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted);
+                                        playbackSkipSilence, playWhenReady);
                             },
                             () -> {
                                 // Completed but not found in history
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted);
+                                        playbackSkipSilence, playWhenReady);
                             }
                     ));
         } else {
             // Good to go...
             // In a case of equal PlayQueues we can re-init old one but only when it is disposed
             initPlayback(samePlayQueue ? playQueue : newQueue, repeatMode, playbackSpeed,
-                    playbackPitch, playbackSkipSilence, playWhenReady, isMuted);
+                    playbackPitch, playbackSkipSilence, playWhenReady);
         }
 
         if (oldPlayerType != playerType && playQueue != null) {
@@ -506,8 +504,7 @@ public final class Player implements PlaybackListener, Listener {
                               final float playbackSpeed,
                               final float playbackPitch,
                               final boolean playbackSkipSilence,
-                              final boolean playOnReady,
-                              final boolean isMuted) {
+                              final boolean playOnReady) {
         destroyPlayer();
         initPlayer(playOnReady);
         setRepeatMode(repeatMode);
@@ -519,7 +516,7 @@ public final class Player implements PlaybackListener, Listener {
 
         UIs.call(PlayerUi::initPlayback);
 
-        simpleExoPlayer.setVolume(isMuted ? 0 : 1);
+        simpleExoPlayer.setVolume(isMuted() ? 0 : 1);
         notifyQueueUpdateToListeners();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -24,12 +24,12 @@ import static com.google.android.exoplayer2.Player.DISCONTINUITY_REASON_SEEK_ADJ
 import static com.google.android.exoplayer2.Player.DISCONTINUITY_REASON_SKIP;
 import static com.google.android.exoplayer2.Player.DiscontinuityReason;
 import static com.google.android.exoplayer2.Player.Listener;
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
 import static com.google.android.exoplayer2.Player.RepeatMode;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
-import static org.schabi.newpipe.player.helper.PlayerHelper.nextRepeatMode;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrievePlaybackParametersFromPrefs;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
 import static org.schabi.newpipe.player.helper.PlayerHelper.savePlaybackParametersToPrefs;
@@ -1172,14 +1172,23 @@ public final class Player implements PlaybackListener, Listener {
         return exoPlayerIsNull() ? REPEAT_MODE_OFF : simpleExoPlayer.getRepeatMode();
     }
 
-    public void setRepeatMode(@RepeatMode final int repeatMode) {
+    public void cycleNextRepeatMode() {
         if (!exoPlayerIsNull()) {
+            @RepeatMode final int repeatMode;
+            switch (simpleExoPlayer.getRepeatMode()) {
+                case REPEAT_MODE_OFF:
+                    repeatMode = REPEAT_MODE_ONE;
+                    break;
+                case REPEAT_MODE_ONE:
+                    repeatMode = REPEAT_MODE_ALL;
+                    break;
+                case REPEAT_MODE_ALL:
+                default:
+                    repeatMode = REPEAT_MODE_OFF;
+                    break;
+            }
             simpleExoPlayer.setRepeatMode(repeatMode);
         }
-    }
-
-    public void cycleNextRepeatMode() {
-        setRepeatMode(nextRepeatMode(getRepeatMode()));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -88,8 +88,8 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorPanelHelper;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
-import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.Image;
+import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
@@ -123,9 +123,9 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
-import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.SerializedCache;
 import org.schabi.newpipe.util.StreamTypeUtil;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.List;
 import java.util.Optional;
@@ -396,9 +396,8 @@ public final class Player implements PlaybackListener, Listener {
                     if (newQueue == null) {
                         return;
                     }
-                    final int currentIndex = playQueue.getIndex();
-                    playQueue.append(newQueue.getStreams());
-                    playQueue.move(playQueue.size() - 1, currentIndex + 1);
+                    final PlayQueueItem newItem = newQueue.getStreams().get(0);
+                    newQueue.enqueueNext(newItem, false);
                 }
                 return;
             }
@@ -410,11 +409,43 @@ public final class Player implements PlaybackListener, Listener {
                 streamItemDisposable.add(single.subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(info -> {
-                            final PlayQueue newPlayQueue =
-                                    new SinglePlayQueue(info, dat.getSeconds() * 1000L);
-                            // TODO: add back the “already playing stream” optimization here
-                            initPlayback(newPlayQueue, playWhenReady);
+                            final @Nullable PlayQueue oldPlayQueue = playQueue;
+                            info.setStartPosition(dat.getSeconds());
+                            final PlayQueueItem playQueueItem = new PlayQueueItem(info);
+
+                            // If the stream is already playing,
+                            // we can just seek to the appropriate timestamp
+                            if (oldPlayQueue != null
+                                    && playQueueItem.isSameItem(oldPlayQueue.getItem())) {
+                                // Player can have state = IDLE when playback is stopped or failed
+                                // and we should retry in this case
+                                if (simpleExoPlayer.getPlaybackState()
+                                        == com.google.android.exoplayer2.Player.STATE_IDLE) {
+                                    simpleExoPlayer.prepare();
+                                }
+                                simpleExoPlayer.seekTo(oldPlayQueue.getIndex(),
+                                        dat.getSeconds() * 1000L);
+                                simpleExoPlayer.setPlayWhenReady(playWhenReady);
+
+                            } else {
+                                final PlayQueue newPlayQueue;
+
+                                // If there is no queue yet, just add our item
+                                if (oldPlayQueue == null) {
+                                    newPlayQueue = new SinglePlayQueue(playQueueItem);
+
+                                // else we add the timestamped stream behind the current video
+                                // and start playing it.
+                                } else {
+                                    oldPlayQueue.enqueueNext(playQueueItem, true);
+                                    oldPlayQueue.offsetIndex(1);
+                                    newPlayQueue = oldPlayQueue;
+                                }
+                                initPlayback(newPlayQueue, playWhenReady);
+                            }
+
                             handleIntentPost(oldPlayerType);
+
                         }, throwable -> {
                             if (DEBUG) {
                                 Log.e(TAG, "Could not play on popup: " + dat.getUrl(), throwable);
@@ -454,7 +485,7 @@ public final class Player implements PlaybackListener, Listener {
         if (!exoPlayerIsNull()
                 && newQueue.size() == 1 && newQueue.getItem() != null
                 && playQueue != null && playQueue.size() == 1 && playQueue.getItem() != null
-                && newQueue.getItem().getUrl().equals(playQueue.getItem().getUrl())
+                && newQueue.getItem().isSameItem(playQueue.getItem())
                 && newQueue.getItem().getRecoveryPosition() != PlayQueueItem.RECOVERY_UNSET) {
             // Player can have state = IDLE when playback is stopped or failed
             // and we should retry in this case
@@ -519,6 +550,7 @@ public final class Player implements PlaybackListener, Listener {
 
         handleIntentPost(oldPlayerType);
     }
+
 
     private void handleIntentPost(final PlayerType oldPlayerType) {
         if (oldPlayerType != playerType && playQueue != null) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -453,7 +453,8 @@ public final class Player implements PlaybackListener, Listener {
                             new AlertDialog.Builder(context)
                                     .setTitle(R.string.player_stream_failure)
                                     .setMessage(
-                                            ErrorPanelHelper.Companion.getExceptionDescription(throwable))
+                                            ErrorPanelHelper.Companion.getExceptionDescription(
+                                                    throwable))
                                     .setPositiveButton(R.string.ok, null)
                                     .show();
                         }));

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -420,7 +420,8 @@ public final class Player implements PlaybackListener, Listener {
 
         } else if (intent.getBooleanExtra(RESUME_PLAYBACK, false)
                 && DependentPreferenceHelper.getResumePlaybackEnabled(context)
-                && !samePlayQueue
+                // !samePlayQueue
+                && (playQueue == null || !playQueue.equalStreamsAndIndex(newQueue))
                 && !newQueue.isEmpty()
                 && newQueue.getItem() != null
                 && newQueue.getItem().getRecoveryPosition() == PlayQueueItem.RECOVERY_UNSET) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -348,6 +348,7 @@ public final class Player implements PlaybackListener, Listener {
         final PlayerType oldPlayerType = playerType;
         playerType = PlayerType.retrieveFromIntent(intent);
         initUIsForCurrentPlayerType();
+        // TODO: what does the following comment mean? Is that a relict?
         // We need to setup audioOnly before super(), see "sourceOf"
         isAudioOnly = audioPlayerSelected();
 
@@ -360,7 +361,7 @@ public final class Player implements PlaybackListener, Listener {
             playQueue.append(newQueue.getStreams());
             return;
 
-            // Resolve enqueue next intents
+        // Resolve enqueue next intents
         } else if (intent.getBooleanExtra(ENQUEUE_NEXT, false) && playQueue != null) {
             final int currentIndex = playQueue.getIndex();
             playQueue.append(newQueue.getStreams());
@@ -368,15 +369,17 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
+        // initPlayback Parameters
         final PlaybackParameters savedParameters = retrievePlaybackParametersFromPrefs(this);
         final float playbackSpeed = savedParameters.speed;
         final float playbackPitch = savedParameters.pitch;
         final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
                 R.string.playback_skip_silence_key), getPlaybackSkipSilence());
-
-        final boolean samePlayQueue = playQueue != null && playQueue.equalStreamsAndIndex(newQueue);
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
+
+        // branching parameters for below
+        final boolean samePlayQueue = playQueue != null && playQueue.equalStreamsAndIndex(newQueue);
 
         /*
          * TODO As seen in #7427 this does not work:

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -122,7 +122,6 @@ import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.SerializedCache;
 import org.schabi.newpipe.util.StreamTypeUtil;
 import org.schabi.newpipe.util.image.PicassoHelper;
@@ -353,13 +352,8 @@ public final class Player implements PlaybackListener, Listener {
         // can move the initUIs stuff without breaking the setup for edge cases somehow.
         switch (playerIntentType) {
             case TimestampChange -> {
-                // TODO: this breaks out of the pattern of asking for the permission before
-                // sending the PlayerIntent, but I’m not sure yet how to combine the permissions
-                // with the new enum approach. Maybe it’s better that the player asks anyway?
-                if (!PermissionHelper.isPopupEnabledElseAsk(context)) {
-                    return;
-                }
-                newPlayerType = PlayerType.POPUP;
+                // when playing from a timestamp, keep the current player as-is.
+                newPlayerType = playerType;
             }
             default -> {
                 newPlayerType = PlayerType.retrieveFromIntent(intent);

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -376,12 +376,6 @@ public final class Player implements PlaybackListener, Listener {
             }
         }
 
-        // initPlayback Parameters
-        final PlaybackParameters savedParameters = retrievePlaybackParametersFromPrefs(this);
-        final float playbackSpeed = savedParameters.speed;
-        final float playbackPitch = savedParameters.pitch;
-        final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
-                R.string.playback_skip_silence_key), getPlaybackSkipSilence());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
 
         // branching parameters for below
@@ -443,28 +437,24 @@ public final class Player implements PlaybackListener, Listener {
                                     newQueue.setRecovery(newQueue.getIndex(),
                                             state.getProgressMillis());
                                 }
-                                initPlayback(newQueue, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady);
+                                initPlayback(newQueue, playWhenReady);
                             },
                             error -> {
                                 if (DEBUG) {
                                     Log.w(TAG, "Failed to start playback", error);
                                 }
                                 // In case any error we can start playback without history
-                                initPlayback(newQueue, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady);
+                                initPlayback(newQueue, playWhenReady);
                             },
                             () -> {
                                 // Completed but not found in history
-                                initPlayback(newQueue, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady);
+                                initPlayback(newQueue, playWhenReady);
                             }
                     ));
         } else {
             // Good to go...
             // In a case of equal PlayQueues we can re-init old one but only when it is disposed
-            initPlayback(samePlayQueue ? playQueue : newQueue, playbackSpeed,
-                    playbackPitch, playbackSkipSilence, playWhenReady);
+            initPlayback(samePlayQueue ? playQueue : newQueue, playWhenReady);
         }
 
         if (oldPlayerType != playerType && playQueue != null) {
@@ -510,13 +500,13 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     private void initPlayback(@NonNull final PlayQueue queue,
-                              final float playbackSpeed,
-                              final float playbackPitch,
-                              final boolean playbackSkipSilence,
                               final boolean playOnReady) {
         destroyPlayer();
         initPlayer(playOnReady);
-        setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
+        final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
+                R.string.playback_skip_silence_key), getPlaybackSkipSilence());
+        final PlaybackParameters savedParameters = retrievePlaybackParametersFromPrefs(this);
+        setPlaybackParameters(savedParameters.speed, savedParameters.pitch, playbackSkipSilence);
 
         playQueue = queue;
         playQueue.init();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -155,11 +155,10 @@ public final class Player implements PlaybackListener, Listener {
     public static final String REPEAT_MODE = "repeat_mode";
     public static final String PLAYBACK_QUALITY = "playback_quality";
     public static final String PLAY_QUEUE_KEY = "play_queue_key";
-    public static final String ENQUEUE = "enqueue";
-    public static final String ENQUEUE_NEXT = "enqueue_next";
     public static final String RESUME_PLAYBACK = "resume_playback";
     public static final String PLAY_WHEN_READY = "play_when_ready";
     public static final String PLAYER_TYPE = "player_type";
+    public static final String PLAYER_INTENT_TYPE = "player_intent_type";
 
     /*//////////////////////////////////////////////////////////////////////////
     // Time constants
@@ -356,22 +355,26 @@ public final class Player implements PlaybackListener, Listener {
             videoResolver.setPlaybackQuality(intent.getStringExtra(PLAYBACK_QUALITY));
         }
 
-        // Resolve enqueue intents
-        if (intent.getBooleanExtra(ENQUEUE, false)) {
-            if (playQueue != null) {
-                playQueue.append(newQueue.getStreams());
-            }
-            return;
-        }
+        final PlayerIntentType playerIntentType = intent.getParcelableExtra(PLAYER_INTENT_TYPE);
 
-        // Resolve enqueue next intents
-        if (intent.getBooleanExtra(ENQUEUE_NEXT, false)) {
-            if (playQueue != null) {
-                final int currentIndex = playQueue.getIndex();
-                playQueue.append(newQueue.getStreams());
-                playQueue.move(playQueue.size() - 1, currentIndex + 1);
+        switch (playerIntentType) {
+            case Enqueue -> {
+                if (playQueue != null) {
+                    playQueue.append(newQueue.getStreams());
+                }
+                return;
             }
-            return;
+            case EnqueueNext -> {
+                if (playQueue != null) {
+                    final int currentIndex = playQueue.getIndex();
+                    playQueue.append(newQueue.getStreams());
+                    playQueue.move(playQueue.size() - 1, currentIndex + 1);
+                }
+                return;
+            }
+            case AllOthers -> {
+                // fallthrough; TODO: put other intent data in separate cases
+            }
         }
 
         // initPlayback Parameters

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -47,6 +47,7 @@ import static org.schabi.newpipe.util.ListHelper.getResolutionIndex;
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -84,6 +85,7 @@ import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.PlayerBinding;
 import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.ErrorPanelHelper;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.stream.AudioStream;
@@ -107,6 +109,7 @@ import org.schabi.newpipe.player.playback.MediaSourceManager;
 import org.schabi.newpipe.player.playback.PlaybackListener;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.player.resolver.AudioPlaybackResolver;
 import org.schabi.newpipe.player.resolver.VideoPlaybackResolver;
 import org.schabi.newpipe.player.resolver.VideoPlaybackResolver.SourceType;
@@ -116,8 +119,10 @@ import org.schabi.newpipe.player.ui.PlayerUiList;
 import org.schabi.newpipe.player.ui.PopupPlayerUi;
 import org.schabi.newpipe.player.ui.VideoPlayerUi;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
+import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.SerializedCache;
 import org.schabi.newpipe.util.StreamTypeUtil;
@@ -128,9 +133,11 @@ import java.util.stream.IntStream;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.disposables.SerialDisposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public final class Player implements PlaybackListener, Listener {
     public static final boolean DEBUG = MainActivity.DEBUG;
@@ -158,6 +165,7 @@ public final class Player implements PlaybackListener, Listener {
     public static final String PLAY_WHEN_READY = "play_when_ready";
     public static final String PLAYER_TYPE = "player_type";
     public static final String PLAYER_INTENT_TYPE = "player_intent_type";
+    public static final String PLAYER_INTENT_DATA = "player_intent_data";
 
     /*//////////////////////////////////////////////////////////////////////////
     // Time constants
@@ -242,6 +250,8 @@ public final class Player implements PlaybackListener, Listener {
     private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
     @NonNull
     private final CompositeDisposable databaseUpdateDisposable = new CompositeDisposable();
+    @NonNull
+    private final CompositeDisposable streamItemDisposable = new CompositeDisposable();
 
     // This is the only listener we need for thumbnail loading, since there is always at most only
     // one thumbnail being loaded at a time. This field is also here to maintain a strong reference,
@@ -333,18 +343,31 @@ public final class Player implements PlaybackListener, Listener {
 
     @SuppressWarnings("MethodLength")
     public void handleIntent(@NonNull final Intent intent) {
-        // fail fast if no play queue was provided
-        final String queueCache = intent.getStringExtra(PLAY_QUEUE_KEY);
-        if (queueCache == null) {
+
+        final PlayerIntentType playerIntentType = intent.getParcelableExtra(PLAYER_INTENT_TYPE);
+        if (playerIntentType == null) {
             return;
         }
-        final PlayQueue newQueue = SerializedCache.getInstance().take(queueCache, PlayQueue.class);
-        if (newQueue == null) {
-            return;
+        final PlayerType newPlayerType;
+        // TODO: this should be in the second switch below, but I’m not sure whether I
+        // can move the initUIs stuff without breaking the setup for edge cases somehow.
+        switch (playerIntentType) {
+            case TimestampChange -> {
+                // TODO: this breaks out of the pattern of asking for the permission before
+                // sending the PlayerIntent, but I’m not sure yet how to combine the permissions
+                // with the new enum approach. Maybe it’s better that the player asks anyway?
+                if (!PermissionHelper.isPopupEnabledElseAsk(context)) {
+                    return;
+                }
+                newPlayerType = PlayerType.POPUP;
+            }
+            default -> {
+                newPlayerType = PlayerType.retrieveFromIntent(intent);
+            }
         }
 
         final PlayerType oldPlayerType = playerType;
-        playerType = PlayerType.retrieveFromIntent(intent);
+        playerType = newPlayerType;
         initUIsForCurrentPlayerType();
         // TODO: what does the following comment mean? Is that a relict?
         // We need to setup audioOnly before super(), see "sourceOf"
@@ -354,21 +377,55 @@ public final class Player implements PlaybackListener, Listener {
             videoResolver.setPlaybackQuality(intent.getStringExtra(PLAYBACK_QUALITY));
         }
 
-        final PlayerIntentType playerIntentType = intent.getParcelableExtra(PLAYER_INTENT_TYPE);
+        final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
 
         switch (playerIntentType) {
             case Enqueue -> {
                 if (playQueue != null) {
+                    final PlayQueue newQueue = getPlayQueueFromCache(intent);
+                    if (newQueue == null) {
+                        return;
+                    }
                     playQueue.append(newQueue.getStreams());
                 }
                 return;
             }
             case EnqueueNext -> {
                 if (playQueue != null) {
+                    final PlayQueue newQueue = getPlayQueueFromCache(intent);
+                    if (newQueue == null) {
+                        return;
+                    }
                     final int currentIndex = playQueue.getIndex();
                     playQueue.append(newQueue.getStreams());
                     playQueue.move(playQueue.size() - 1, currentIndex + 1);
                 }
+                return;
+            }
+            case TimestampChange -> {
+                final TimestampChangeData dat = intent.getParcelableExtra(PLAYER_INTENT_DATA);
+                assert dat != null;
+                final Single<StreamInfo> single =
+                        ExtractorHelper.getStreamInfo(dat.getServiceId(), dat.getUrl(), false);
+                streamItemDisposable.add(single.subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(info -> {
+                            final PlayQueue newPlayQueue =
+                                    new SinglePlayQueue(info, dat.getSeconds() * 1000L);
+                            // TODO: add back the “already playing stream” optimization here
+                            initPlayback(newPlayQueue, playWhenReady);
+                            handleIntentPost(oldPlayerType);
+                        }, throwable -> {
+                            if (DEBUG) {
+                                Log.e(TAG, "Could not play on popup: " + dat.getUrl(), throwable);
+                            }
+                            new AlertDialog.Builder(context)
+                                    .setTitle(R.string.player_stream_failure)
+                                    .setMessage(
+                                            ErrorPanelHelper.Companion.getExceptionDescription(throwable))
+                                    .setPositiveButton(R.string.ok, null)
+                                    .show();
+                        }));
                 return;
             }
             case AllOthers -> {
@@ -376,7 +433,10 @@ public final class Player implements PlaybackListener, Listener {
             }
         }
 
-        final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
+        final PlayQueue newQueue = getPlayQueueFromCache(intent);
+        if (newQueue == null) {
+            return;
+        }
 
         // branching parameters for below
         final boolean samePlayQueue = playQueue != null && playQueue.equalStreamsAndIndex(newQueue);
@@ -457,6 +517,10 @@ public final class Player implements PlaybackListener, Listener {
             initPlayback(samePlayQueue ? playQueue : newQueue, playWhenReady);
         }
 
+        handleIntentPost(oldPlayerType);
+    }
+
+    private void handleIntentPost(final PlayerType oldPlayerType) {
         if (oldPlayerType != playerType && playQueue != null) {
             // If playerType changes from one to another we should reload the player
             // (to disable/enable video stream or to set quality)
@@ -465,6 +529,19 @@ public final class Player implements PlaybackListener, Listener {
 
         UIs.call(PlayerUi::setupAfterIntent);
         NavigationHelper.sendPlayerStartedEvent(context);
+    }
+
+    @Nullable
+    private static PlayQueue getPlayQueueFromCache(@NonNull final Intent intent) {
+        final String queueCache = intent.getStringExtra(PLAY_QUEUE_KEY);
+        if (queueCache == null) {
+            return null;
+        }
+        final PlayQueue newQueue = SerializedCache.getInstance().take(queueCache, PlayQueue.class);
+        if (newQueue == null) {
+            return null;
+        }
+        return newQueue;
     }
 
     private void initUIsForCurrentPlayerType() {
@@ -596,6 +673,7 @@ public final class Player implements PlaybackListener, Listener {
 
         databaseUpdateDisposable.clear();
         progressUpdateDisposable.set(null);
+        streamItemDisposable.clear();
         cancelLoadingCurrentThumbnail();
 
         UIs.destroyAll(Object.class); // destroy every UI: obviously every UI extends Object

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -152,7 +152,6 @@ public final class Player implements PlaybackListener, Listener {
     // Intent
     //////////////////////////////////////////////////////////////////////////*/
 
-    public static final String REPEAT_MODE = "repeat_mode";
     public static final String PLAYBACK_QUALITY = "playback_quality";
     public static final String PLAY_QUEUE_KEY = "play_queue_key";
     public static final String RESUME_PLAYBACK = "resume_playback";
@@ -383,7 +382,6 @@ public final class Player implements PlaybackListener, Listener {
         final float playbackPitch = savedParameters.pitch;
         final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
                 R.string.playback_skip_silence_key), getPlaybackSkipSilence());
-        final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
 
         // branching parameters for below
@@ -445,7 +443,7 @@ public final class Player implements PlaybackListener, Listener {
                                     newQueue.setRecovery(newQueue.getIndex(),
                                             state.getProgressMillis());
                                 }
-                                initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
+                                initPlayback(newQueue, playbackSpeed, playbackPitch,
                                         playbackSkipSilence, playWhenReady);
                             },
                             error -> {
@@ -453,19 +451,19 @@ public final class Player implements PlaybackListener, Listener {
                                     Log.w(TAG, "Failed to start playback", error);
                                 }
                                 // In case any error we can start playback without history
-                                initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
+                                initPlayback(newQueue, playbackSpeed, playbackPitch,
                                         playbackSkipSilence, playWhenReady);
                             },
                             () -> {
                                 // Completed but not found in history
-                                initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
+                                initPlayback(newQueue, playbackSpeed, playbackPitch,
                                         playbackSkipSilence, playWhenReady);
                             }
                     ));
         } else {
             // Good to go...
             // In a case of equal PlayQueues we can re-init old one but only when it is disposed
-            initPlayback(samePlayQueue ? playQueue : newQueue, repeatMode, playbackSpeed,
+            initPlayback(samePlayQueue ? playQueue : newQueue, playbackSpeed,
                     playbackPitch, playbackSkipSilence, playWhenReady);
         }
 
@@ -512,14 +510,12 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     private void initPlayback(@NonNull final PlayQueue queue,
-                              @RepeatMode final int repeatMode,
                               final float playbackSpeed,
                               final float playbackPitch,
                               final boolean playbackSkipSilence,
                               final boolean playOnReady) {
         destroyPlayer();
         initPlayer(playOnReady);
-        setRepeatMode(repeatMode);
         setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
 
         playQueue = queue;

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerIntentType.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerIntentType.kt
@@ -11,5 +11,16 @@ import kotlinx.parcelize.Parcelize
 enum class PlayerIntentType : Parcelable {
     Enqueue,
     EnqueueNext,
+    TimestampChange,
     AllOthers
 }
+
+/**
+ * A timestamp on the given was clicked and we should switch the playing stream to it.
+ */
+@Parcelize
+data class TimestampChangeData(
+    val serviceId: Int,
+    val url: String,
+    val seconds: Int
+) : Parcelable

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerIntentType.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerIntentType.kt
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.player
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+// We model this as an enum class plus one struct for each enum value
+// so we can consume it from Java properly. After converting to Kotlin,
+// we could switch to a sealed enum class & a proper Kotlin `when` match.
+
+@Parcelize
+enum class PlayerIntentType : Parcelable {
+    Enqueue,
+    EnqueueNext,
+    AllOthers
+}

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -1,8 +1,5 @@
 package org.schabi.newpipe.player.helper;
 
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
 import static org.schabi.newpipe.player.helper.PlayerHelper.AutoplayType.AUTOPLAY_TYPE_ALWAYS;
 import static org.schabi.newpipe.player.helper.PlayerHelper.AutoplayType.AUTOPLAY_TYPE_NEVER;
 import static org.schabi.newpipe.player.helper.PlayerHelper.AutoplayType.AUTOPLAY_TYPE_WIFI;
@@ -25,7 +22,6 @@ import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.exoplayer2.PlaybackParameters;
-import com.google.android.exoplayer2.Player.RepeatMode;
 import com.google.android.exoplayer2.SeekParameters;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
@@ -429,20 +425,6 @@ public final class PlayerHelper {
 
     ////////////////////////////////////////////////////////////////////////////
     // Utils used by player
-    ////////////////////////////////////////////////////////////////////////////
-
-    @RepeatMode
-    public static int nextRepeatMode(@RepeatMode final int repeatMode) {
-        switch (repeatMode) {
-            case REPEAT_MODE_OFF:
-                return REPEAT_MODE_ONE;
-            case REPEAT_MODE_ONE:
-                return REPEAT_MODE_ALL;
-            case REPEAT_MODE_ALL:
-            default:
-                return REPEAT_MODE_OFF;
-        }
-    }
 
     @ResizeMode
     public static int retrieveResizeModeFromPrefs(final Player player) {

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -23,6 +23,7 @@ import androidx.core.content.ContextCompat;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.PlayerIntentType;
 import org.schabi.newpipe.player.mediasession.MediaSessionPlayerUi;
 import org.schabi.newpipe.util.NavigationHelper;
 
@@ -256,7 +257,8 @@ public final class NotificationUtil {
         } else {
             // We are playing in fragment. Don't open another activity just show fragment. That's it
             final Intent intent = NavigationHelper.getPlayerIntent(
-                    player.getContext(), MainActivity.class, null);
+                    player.getContext(), MainActivity.class, null,
+                    PlayerIntentType.AllOthers);
             intent.putExtra(Player.RESUME_PLAYBACK, true);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setAction(Intent.ACTION_MAIN);

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -256,7 +256,8 @@ public final class NotificationUtil {
         } else {
             // We are playing in fragment. Don't open another activity just show fragment. That's it
             final Intent intent = NavigationHelper.getPlayerIntent(
-                    player.getContext(), MainActivity.class, null, true);
+                    player.getContext(), MainActivity.class, null);
+            intent.putExtra(Player.RESUME_PLAYBACK, true);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setAction(Intent.ACTION_MAIN);
             intent.addCategory(Intent.CATEGORY_LAUNCHER);

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -292,6 +292,22 @@ public abstract class PlayQueue implements Serializable {
     }
 
     /**
+     * Add the given item after the current stream.
+     *
+     * @param item item to add.
+     * @param skipIfSame if set, skip adding if the next stream is the same stream.
+     */
+    public void enqueueNext(@NonNull final PlayQueueItem item, final boolean skipIfSame) {
+        final int currentIndex = getIndex();
+        // if the next item is the same item as the one we want to enqueue, skip if flag is true
+        if (skipIfSame && item.isSameItem(getItem(currentIndex + 1))) {
+            return;
+        }
+        append(List.of(item));
+        move(size() - 1, currentIndex + 1);
+    }
+
+    /**
      * Removes the item at the given index from the play queue.
      * <p>
      * The current playing index will decrement if it is greater than the index being removed.
@@ -529,8 +545,7 @@ public abstract class PlayQueue implements Serializable {
             final PlayQueueItem stream = streams.get(i);
             final PlayQueueItem otherStream = other.streams.get(i);
             // Check is based on serviceId and URL
-            if (stream.getServiceId() != otherStream.getServiceId()
-                    || !stream.getUrl().equals(otherStream.getUrl())) {
+            if (!stream.isSameItem(otherStream)) {
                 return false;
             }
         }

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
@@ -38,7 +38,7 @@ public class PlayQueueItem implements Serializable {
     private long recoveryPosition;
     private Throwable error;
 
-    PlayQueueItem(@NonNull final StreamInfo info) {
+    public PlayQueueItem(@NonNull final StreamInfo info) {
         this(info.getName(), info.getUrl(), info.getServiceId(), info.getDuration(),
                 info.getThumbnails(), info.getUploaderName(),
                 info.getUploaderUrl(), info.getStreamType());
@@ -69,6 +69,22 @@ public class PlayQueueItem implements Serializable {
         this.streamType = streamType;
 
         this.recoveryPosition = RECOVERY_UNSET;
+    }
+
+    /** Whether these two items should be treated as the same stream
+     * for the sake of keeping the same player running when e.g. jumping between timestamps.
+     *
+     * @param other the {@link PlayQueueItem} to compare against.
+     * @return whether the two items are the same so the stream can be re-used.
+     */
+    public boolean isSameItem(@Nullable final PlayQueueItem other) {
+        if (other == null) {
+            return false;
+        }
+        // We assume that the same service & URL uniquely determines
+        // that we can keep the same stream running.
+        return getServiceId() == other.getServiceId()
+                && getUrl().equals(other.getUrl());
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/SinglePlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/SinglePlayQueue.java
@@ -16,7 +16,9 @@ public final class SinglePlayQueue extends PlayQueue {
     public SinglePlayQueue(final StreamInfo info) {
         super(0, List.of(new PlayQueueItem(info)));
     }
-
+    public SinglePlayQueue(final PlayQueueItem item) {
+        super(0, List.of(item));
+    }
     public SinglePlayQueue(final StreamInfo info, final long startPosition) {
         super(0, List.of(new PlayQueueItem(info)));
         getItem().setRecoveryPosition(startPosition);

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -100,17 +100,6 @@ public final class NavigationHelper {
     }
 
     @NonNull
-    public static <T> Intent getPlayerIntent(@NonNull final Context context,
-                                             @NonNull final Class<T> targetClazz,
-                                             @Nullable final PlayQueue playQueue,
-                                             final boolean resumePlayback,
-                                             final boolean playWhenReady) {
-        return getPlayerIntent(context, targetClazz, playQueue)
-                .putExtra(Player.PLAY_WHEN_READY, playWhenReady)
-                .putExtra(Player.RESUME_PLAYBACK, resumePlayback);
-    }
-
-    @NonNull
     public static <T> Intent getPlayerEnqueueNextIntent(@NonNull final Context context,
                                                         @NonNull final Class<T> targetClazz,
                                                         @Nullable final PlayQueue playQueue) {

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -111,21 +111,6 @@ public final class NavigationHelper {
     }
 
     @NonNull
-    public static <T> Intent getPlayerEnqueueIntent(@NonNull final Context context,
-                                                    @NonNull final Class<T> targetClazz,
-                                                    @Nullable final PlayQueue playQueue) {
-        // when enqueueing `resumePlayback` is always `false` since:
-        // - if there is a video already playing, the value of `resumePlayback` just doesn't make
-        //   any difference.
-        // - if there is nothing already playing, it is useful for the enqueue action to have a
-        //   slightly different behaviour than the normal play action: the latter resumes playback,
-        //   the former doesn't. (note that enqueue can be triggered when nothing is playing only
-        //   by long pressing the video detail fragment, playlist or channel controls
-        return getPlayerIntent(context, targetClazz, playQueue, false)
-                .putExtra(Player.ENQUEUE, true);
-    }
-
-    @NonNull
     public static <T> Intent getPlayerEnqueueNextIntent(@NonNull final Context context,
                                                         @NonNull final Class<T> targetClazz,
                                                         @Nullable final PlayQueue playQueue) {
@@ -190,7 +175,15 @@ public final class NavigationHelper {
         }
 
         Toast.makeText(context, R.string.enqueued, Toast.LENGTH_SHORT).show();
-        final Intent intent = getPlayerEnqueueIntent(context, PlayerService.class, queue);
+        // when enqueueing `resumePlayback` is always `false` since:
+        // - if there is a video already playing, the value of `resumePlayback` just doesn't make
+        //   any difference.
+        // - if there is nothing already playing, it is useful for the enqueue action to have a
+        //   slightly different behaviour than the normal play action: the latter resumes playback,
+        //   the former doesn't. (note that enqueue can be triggered when nothing is playing only
+        //   by long pressing the video detail fragment, playlist or channel controls
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue, false)
+                .putExtra(Player.ENQUEUE, true);
 
         intent.putExtra(Player.PLAYER_TYPE, playerType.valueForIntent());
         ContextCompat.startForegroundService(context, intent);

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -61,6 +61,7 @@ import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.PlayerIntentType;
 import org.schabi.newpipe.player.PlayerService;
 import org.schabi.newpipe.player.PlayerType;
+import org.schabi.newpipe.player.TimestampChangeData;
 import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
@@ -98,6 +99,18 @@ public final class NavigationHelper {
         }
         intent.putExtra(Player.PLAYER_TYPE, PlayerType.MAIN.valueForIntent());
         intent.putExtra(Player.PLAYER_INTENT_TYPE, (Parcelable) playerIntentType);
+
+        return intent;
+    }
+
+    @NonNull
+    public static Intent getPlayerTimestampIntent(@NonNull final Context context,
+                                                   @NonNull final TimestampChangeData
+                                                           timestampChangeData) {
+        final Intent intent = new Intent(context, PlayerService.class);
+
+        intent.putExtra(Player.PLAYER_INTENT_TYPE, (Parcelable) PlayerIntentType.TimestampChange);
+        intent.putExtra(Player.PLAYER_INTENT_DATA, timestampChangeData);
 
         return intent;
     }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Parcelable;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -57,6 +58,7 @@ import org.schabi.newpipe.local.subscription.SubscriptionFragment;
 import org.schabi.newpipe.local.subscription.SubscriptionsImportFragment;
 import org.schabi.newpipe.player.PlayQueueActivity;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.PlayerIntentType;
 import org.schabi.newpipe.player.PlayerService;
 import org.schabi.newpipe.player.PlayerType;
 import org.schabi.newpipe.player.helper.PlayerHelper;
@@ -84,7 +86,8 @@ public final class NavigationHelper {
     @NonNull
     public static <T> Intent getPlayerIntent(@NonNull final Context context,
                                              @NonNull final Class<T> targetClazz,
-                                             @Nullable final PlayQueue playQueue) {
+                                             @Nullable final PlayQueue playQueue,
+                                             @NonNull final PlayerIntentType playerIntentType) {
         final Intent intent = new Intent(context, targetClazz);
 
         if (playQueue != null) {
@@ -94,7 +97,7 @@ public final class NavigationHelper {
             }
         }
         intent.putExtra(Player.PLAYER_TYPE, PlayerType.MAIN.valueForIntent());
-        intent.putExtra(Player.RESUME_PLAYBACK, resumePlayback);
+        intent.putExtra(Player.PLAYER_INTENT_TYPE, (Parcelable) playerIntentType);
 
         return intent;
     }
@@ -103,8 +106,7 @@ public final class NavigationHelper {
     public static <T> Intent getPlayerEnqueueNextIntent(@NonNull final Context context,
                                                         @NonNull final Class<T> targetClazz,
                                                         @Nullable final PlayQueue playQueue) {
-        return getPlayerIntent(context, targetClazz, playQueue)
-                .putExtra(Player.ENQUEUE_NEXT, true)
+        return getPlayerIntent(context, targetClazz, playQueue, PlayerIntentType.EnqueueNext)
                 // see comment in `getPlayerEnqueueIntent` as to why `resumePlayback` is false
                 .putExtra(Player.RESUME_PLAYBACK, false);
     }
@@ -140,7 +142,8 @@ public final class NavigationHelper {
 
         Toast.makeText(context, R.string.popup_playing_toast, Toast.LENGTH_SHORT).show();
 
-        final Intent intent = getPlayerIntent(context, PlayerService.class, queue);
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue,
+                PlayerIntentType.AllOthers);
         intent.putExtra(Player.PLAYER_TYPE, PlayerType.POPUP.valueForIntent())
                 .putExtra(Player.RESUME_PLAYBACK, resumePlayback);
         ContextCompat.startForegroundService(context, intent);
@@ -152,7 +155,8 @@ public final class NavigationHelper {
         Toast.makeText(context, R.string.background_player_playing_toast, Toast.LENGTH_SHORT)
                 .show();
 
-        final Intent intent = getPlayerIntent(context, PlayerService.class, queue);
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue,
+                PlayerIntentType.AllOthers);
         intent.putExtra(Player.PLAYER_TYPE, PlayerType.AUDIO.valueForIntent());
         intent.putExtra(Player.RESUME_PLAYBACK, resumePlayback);
         ContextCompat.startForegroundService(context, intent);
@@ -175,8 +179,8 @@ public final class NavigationHelper {
         //   slightly different behaviour than the normal play action: the latter resumes playback,
         //   the former doesn't. (note that enqueue can be triggered when nothing is playing only
         //   by long pressing the video detail fragment, playlist or channel controls
-        final Intent intent = getPlayerIntent(context, PlayerService.class, queue)
-                .putExtra(Player.ENQUEUE, true)
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue,
+                PlayerIntentType.Enqueue)
                 .putExtra(Player.RESUME_PLAYBACK, false);
 
         intent.putExtra(Player.PLAYER_TYPE, playerType.valueForIntent());

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -84,8 +84,7 @@ public final class NavigationHelper {
     @NonNull
     public static <T> Intent getPlayerIntent(@NonNull final Context context,
                                              @NonNull final Class<T> targetClazz,
-                                             @Nullable final PlayQueue playQueue,
-                                             final boolean resumePlayback) {
+                                             @Nullable final PlayQueue playQueue) {
         final Intent intent = new Intent(context, targetClazz);
 
         if (playQueue != null) {
@@ -106,17 +105,19 @@ public final class NavigationHelper {
                                              @Nullable final PlayQueue playQueue,
                                              final boolean resumePlayback,
                                              final boolean playWhenReady) {
-        return getPlayerIntent(context, targetClazz, playQueue, resumePlayback)
-                .putExtra(Player.PLAY_WHEN_READY, playWhenReady);
+        return getPlayerIntent(context, targetClazz, playQueue)
+                .putExtra(Player.PLAY_WHEN_READY, playWhenReady)
+                .putExtra(Player.RESUME_PLAYBACK, resumePlayback);
     }
 
     @NonNull
     public static <T> Intent getPlayerEnqueueNextIntent(@NonNull final Context context,
                                                         @NonNull final Class<T> targetClazz,
                                                         @Nullable final PlayQueue playQueue) {
-        // see comment in `getPlayerEnqueueIntent` as to why `resumePlayback` is false
-        return getPlayerIntent(context, targetClazz, playQueue, false)
-                .putExtra(Player.ENQUEUE_NEXT, true);
+        return getPlayerIntent(context, targetClazz, playQueue)
+                .putExtra(Player.ENQUEUE_NEXT, true)
+                // see comment in `getPlayerEnqueueIntent` as to why `resumePlayback` is false
+                .putExtra(Player.RESUME_PLAYBACK, false);
     }
 
     /* PLAY */
@@ -150,8 +151,9 @@ public final class NavigationHelper {
 
         Toast.makeText(context, R.string.popup_playing_toast, Toast.LENGTH_SHORT).show();
 
-        final Intent intent = getPlayerIntent(context, PlayerService.class, queue, resumePlayback);
-        intent.putExtra(Player.PLAYER_TYPE, PlayerType.POPUP.valueForIntent());
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue);
+        intent.putExtra(Player.PLAYER_TYPE, PlayerType.POPUP.valueForIntent())
+                .putExtra(Player.RESUME_PLAYBACK, resumePlayback);
         ContextCompat.startForegroundService(context, intent);
     }
 
@@ -161,8 +163,9 @@ public final class NavigationHelper {
         Toast.makeText(context, R.string.background_player_playing_toast, Toast.LENGTH_SHORT)
                 .show();
 
-        final Intent intent = getPlayerIntent(context, PlayerService.class, queue, resumePlayback);
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue);
         intent.putExtra(Player.PLAYER_TYPE, PlayerType.AUDIO.valueForIntent());
+        intent.putExtra(Player.RESUME_PLAYBACK, resumePlayback);
         ContextCompat.startForegroundService(context, intent);
     }
 
@@ -175,6 +178,7 @@ public final class NavigationHelper {
         }
 
         Toast.makeText(context, R.string.enqueued, Toast.LENGTH_SHORT).show();
+
         // when enqueueing `resumePlayback` is always `false` since:
         // - if there is a video already playing, the value of `resumePlayback` just doesn't make
         //   any difference.
@@ -182,8 +186,9 @@ public final class NavigationHelper {
         //   slightly different behaviour than the normal play action: the latter resumes playback,
         //   the former doesn't. (note that enqueue can be triggered when nothing is playing only
         //   by long pressing the video detail fragment, playlist or channel controls
-        final Intent intent = getPlayerIntent(context, PlayerService.class, queue, false)
-                .putExtra(Player.ENQUEUE, true);
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue)
+                .putExtra(Player.ENQUEUE, true)
+                .putExtra(Player.RESUME_PLAYBACK, false);
 
         intent.putExtra(Player.PLAYER_TYPE, playerType.valueForIntent());
         ContextCompat.startForegroundService(context, intent);

--- a/app/src/main/java/org/schabi/newpipe/util/text/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/InternalUrlsHandler.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
-import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -18,15 +17,11 @@ import org.schabi.newpipe.util.NavigationHelper;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
-
 public final class InternalUrlsHandler {
-    private static final String TAG = InternalUrlsHandler.class.getSimpleName();
-    private static final boolean DEBUG = MainActivity.DEBUG;
-
     private static final Pattern AMPERSAND_TIMESTAMP_PATTERN = Pattern.compile("(.*)&t=(\\d+)");
-    private static final Pattern HASHTAG_TIMESTAMP_PATTERN =
-            Pattern.compile("(.*)#timestamp=(\\d+)");
+
+    private InternalUrlsHandler() {
+    }
 
     /**
      * Handle a YouTube timestamp description URL in NewPipe.
@@ -36,14 +31,11 @@ public final class InternalUrlsHandler {
      * player will be opened when the user will click on the timestamp in the video description,
      * at the time and for the video indicated in the timestamp.
      *
-     * @param disposables a field of the Activity/Fragment class that calls this method
      * @param context     the context to use
      * @param url         the URL to check if it can be handled
      * @return true if the URL can be handled by NewPipe, false if it cannot
      */
-    public static boolean handleUrlDescriptionTimestamp(@NonNull final CompositeDisposable
-                                                                disposables,
-                                                        final Context context,
+    public static boolean handleUrlDescriptionTimestamp(final Context context,
                                                         @NonNull final String url) {
         final Matcher matcher = AMPERSAND_TIMESTAMP_PATTERN.matcher(url);
         if (!matcher.matches()) {
@@ -70,7 +62,7 @@ public final class InternalUrlsHandler {
         }
 
         if (linkType == StreamingService.LinkType.STREAM && seconds != -1) {
-            return playOnPopup(context, matchedUrl, service, seconds, disposables);
+            return playOnPopup(context, matchedUrl, service, seconds);
         } else {
             NavigationHelper.openRouterActivity(context, matchedUrl);
             return true;
@@ -84,15 +76,12 @@ public final class InternalUrlsHandler {
      * @param url         the URL of the content
      * @param service     the service of the content
      * @param seconds     the position in seconds at which the floating player will start
-     * @param disposables disposables created by the method are added here and their lifecycle
-     *                    should be handled by the calling class
      * @return true if the playback of the content has successfully started or false if not
      */
     public static boolean playOnPopup(final Context context,
                                       final String url,
                                       @NonNull final StreamingService service,
-                                      final int seconds,
-                                      @NonNull final CompositeDisposable disposables) {
+                                      final int seconds) {
         final LinkHandlerFactory factory = service.getStreamLHFactory();
         final String cleanUrl;
 

--- a/app/src/main/java/org/schabi/newpipe/util/text/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/InternalUrlsHandler.java
@@ -1,32 +1,24 @@
 package org.schabi.newpipe.util.text;
 
 import android.content.Context;
-import android.util.Log;
+import android.content.Intent;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
 
 import org.schabi.newpipe.MainActivity;
-import org.schabi.newpipe.R;
-import org.schabi.newpipe.error.ErrorPanelHelper;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
-import org.schabi.newpipe.extractor.stream.StreamInfo;
-import org.schabi.newpipe.player.playqueue.PlayQueue;
-import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
-import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.player.TimestampChangeData;
 import org.schabi.newpipe.util.NavigationHelper;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
-import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public final class InternalUrlsHandler {
     private static final String TAG = InternalUrlsHandler.class.getSimpleName();
@@ -35,29 +27,6 @@ public final class InternalUrlsHandler {
     private static final Pattern AMPERSAND_TIMESTAMP_PATTERN = Pattern.compile("(.*)&t=(\\d+)");
     private static final Pattern HASHTAG_TIMESTAMP_PATTERN =
             Pattern.compile("(.*)#timestamp=(\\d+)");
-
-    private InternalUrlsHandler() {
-    }
-
-    /**
-     * Handle a YouTube timestamp comment URL in NewPipe.
-     * <p>
-     * This method will check if the provided url is a YouTube comment description URL ({@code
-     * https://www.youtube.com/watch?v=}video_id{@code #timestamp=}time_in_seconds). If yes, the
-     * popup player will be opened when the user will click on the timestamp in the comment,
-     * at the time and for the video indicated in the timestamp.
-     *
-     * @param disposables a field of the Activity/Fragment class that calls this method
-     * @param context     the context to use
-     * @param url         the URL to check if it can be handled
-     * @return true if the URL can be handled by NewPipe, false if it cannot
-     */
-    public static boolean handleUrlCommentsTimestamp(@NonNull final CompositeDisposable
-                                                             disposables,
-                                                     final Context context,
-                                                     @NonNull final String url) {
-        return handleUrl(context, url, HASHTAG_TIMESTAMP_PATTERN, disposables);
-    }
 
     /**
      * Handle a YouTube timestamp description URL in NewPipe.
@@ -76,27 +45,7 @@ public final class InternalUrlsHandler {
                                                                 disposables,
                                                         final Context context,
                                                         @NonNull final String url) {
-        return handleUrl(context, url, AMPERSAND_TIMESTAMP_PATTERN, disposables);
-    }
-
-    /**
-     * Handle an URL in NewPipe.
-     * <p>
-     * This method will check if the provided url can be handled in NewPipe or not. If this is a
-     * service URL with a timestamp, the popup player will be opened and true will be returned;
-     * else, false will be returned.
-     *
-     * @param context     the context to use
-     * @param url         the URL to check if it can be handled
-     * @param pattern     the pattern to use
-     * @param disposables a field of the Activity/Fragment class that calls this method
-     * @return true if the URL can be handled by NewPipe, false if it cannot
-     */
-    private static boolean handleUrl(final Context context,
-                                     @NonNull final String url,
-                                     @NonNull final Pattern pattern,
-                                     @NonNull final CompositeDisposable disposables) {
-        final Matcher matcher = pattern.matcher(url);
+        final Matcher matcher = AMPERSAND_TIMESTAMP_PATTERN.matcher(url);
         if (!matcher.matches()) {
             return false;
         }
@@ -153,25 +102,13 @@ public final class InternalUrlsHandler {
             return false;
         }
 
-        final Single<StreamInfo> single =
-                ExtractorHelper.getStreamInfo(service.getServiceId(), cleanUrl, false);
-        disposables.add(single.subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(info -> {
-                    final PlayQueue playQueue =
-                            new SinglePlayQueue(info, seconds * 1000L);
-                    NavigationHelper.playOnPopupPlayer(context, playQueue, false);
-                }, throwable -> {
-                    if (DEBUG) {
-                        Log.e(TAG, "Could not play on popup: " + url, throwable);
-                    }
-                    new AlertDialog.Builder(context)
-                            .setTitle(R.string.player_stream_failure)
-                            .setMessage(
-                                    ErrorPanelHelper.Companion.getExceptionDescription(throwable))
-                            .setPositiveButton(R.string.ok, null)
-                            .show();
-                }));
+        final Intent intent = NavigationHelper.getPlayerTimestampIntent(context,
+                new TimestampChangeData(
+                        service.getServiceId(),
+                        cleanUrl,
+                        seconds
+                ));
+        ContextCompat.startForegroundService(context, intent);
         return true;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/text/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/TextLinkifier.java
@@ -192,7 +192,7 @@ public final class TextLinkifier {
      * <p>
      * Instead of using an {@link android.content.Intent#ACTION_VIEW} intent in the description of
      * a content, this method will parse the {@link CharSequence} and replace all current web links
-     * with {@link ShareUtils#openUrlInBrowser(Context, String, boolean)}.
+     * with {@link ShareUtils#openUrlInBrowser(Context, String)}.
      * </p>
      *
      * <p>
@@ -240,7 +240,7 @@ public final class TextLinkifier {
                     for (final URLSpan span : urls) {
                         final String url = span.getURL();
                         final LongPressClickableSpan longPressClickableSpan =
-                                new UrlLongPressClickableSpan(context, disposables, url);
+                                new UrlLongPressClickableSpan(context, url);
 
                         textBlockLinked.setSpan(longPressClickableSpan,
                                 textBlockLinked.getSpanStart(span),

--- a/app/src/main/java/org/schabi/newpipe/util/text/TimestampLongPressClickableSpan.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/TimestampLongPressClickableSpan.java
@@ -45,8 +45,7 @@ final class TimestampLongPressClickableSpan extends LongPressClickableSpan {
 
     @Override
     public void onClick(@NonNull final View view) {
-        playOnPopup(context, relatedStreamUrl, relatedInfoService,
-                timestampMatchDTO.seconds(), disposables);
+        playOnPopup(context, relatedStreamUrl, relatedInfoService, timestampMatchDTO.seconds());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/util/text/UrlLongPressClickableSpan.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/UrlLongPressClickableSpan.java
@@ -7,29 +7,22 @@ import androidx.annotation.NonNull;
 
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
-
 final class UrlLongPressClickableSpan extends LongPressClickableSpan {
 
     @NonNull
     private final Context context;
     @NonNull
-    private final CompositeDisposable disposables;
-    @NonNull
     private final String url;
 
     UrlLongPressClickableSpan(@NonNull final Context context,
-                              @NonNull final CompositeDisposable disposables,
                               @NonNull final String url) {
         this.context = context;
-        this.disposables = disposables;
         this.url = url;
     }
 
     @Override
     public void onClick(@NonNull final View view) {
-        if (!InternalUrlsHandler.handleUrlDescriptionTimestamp(
-                disposables, context, url)) {
+        if (!InternalUrlsHandler.handleUrlDescriptionTimestamp(context, url)) {
             ShareUtils.openUrlInApp(context, url);
         }
     }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This PR includes one extra commit from Newpipe developer Propatsch which also helps keep current player when clicking on timestamp, huge thanks to him.

#### Fixes the following issue(s)
- Fixes:
 1) Tapping on timestamps clears queue since v0.27.0 of NewPipe
 2) Tapping Timestamps starts playing in Pop Player window instead of seeking to that timestamp in current Player. Last commit of this PR makes the player stay the same when a timestamp is pressed instead of always opening the popup player.

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

Link to apk generated from actions https://github.com/whistlingwoods/FoxPipe/actions/runs/16602013625/artifacts/3641042781
#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
