### PR TITLE
Fix crash on screen rotation while entering SoundCloud import URL

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/ImportConfirmationDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/ImportConfirmationDialog.java
@@ -18,16 +18,15 @@ import org.schabi.newpipe.R;
 public class ImportConfirmationDialog extends DialogFragment {
     @State
     protected Intent resultServiceIntent;
+    static final String EXTRA_RESULT_SERVICE_INTENT = "extra_result_service_intent";
 
     public static void show(@NonNull final Fragment fragment,
                             @NonNull final Intent resultServiceIntent) {
         final ImportConfirmationDialog confirmationDialog = new ImportConfirmationDialog();
-        confirmationDialog.setResultServiceIntent(resultServiceIntent);
+        final Bundle args = new Bundle();
+        args.putParcelable(EXTRA_RESULT_SERVICE_INTENT, resultServiceIntent);
+        confirmationDialog.setArguments(args);
         confirmationDialog.show(fragment.getParentFragmentManager(), null);
-    }
-
-    public void setResultServiceIntent(final Intent resultServiceIntent) {
-        this.resultServiceIntent = resultServiceIntent;
     }
 
     @NonNull
@@ -49,6 +48,10 @@ public class ImportConfirmationDialog extends DialogFragment {
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (getArguments() != null) {
+            resultServiceIntent = getArguments().getParcelable(EXTRA_RESULT_SERVICE_INTENT);
+        }
 
         if (resultServiceIntent == null) {
             throw new IllegalStateException("Result intent is null");


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
- Preserved the service Intent across configuration changes (e.g. screen rotation)
- Ensured the dialog safely restores its state after recreation
- Prevented null access when the dialog is recreated by the system

#### Fixes the following issue(s)
- Fixes
- UI error crash when rotating screen while typing url to import soundcloud file

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
