### PR TITLE
[Fix] PeerTube instances list link in settings not being clickable

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -4,11 +4,9 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.Html;
 import android.text.InputType;
-import android.text.SpannableString;
-import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
-import android.text.style.URLSpan;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -89,21 +87,11 @@ public class PeertubeInstanceListFragment extends Fragment {
         super.onViewCreated(rootView, savedInstanceState);
 
         final String instanceListUrl = getString(R.string.peertube_instance_list_url);
-        final String helpText = getString(R.string.peertube_instance_url_help, instanceListUrl);
-        final SpannableString spannableString = new SpannableString(helpText);
-        
-        final int urlStart = helpText.indexOf(instanceListUrl);
-        if (urlStart != -1) {
-            spannableString.setSpan(
-                    new URLSpan(instanceListUrl),
-                    urlStart,
-                    urlStart + instanceListUrl.length(),
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-            );
-        }
-        
-        binding.instanceHelpTV.setText(spannableString);
+        final String helpText = getString(R.string.peertube_instance_url_help,
+                "<a href=\"" + instanceListUrl + "\">" + instanceListUrl + "</a>");
+        binding.instanceHelpTV.setText(Html.fromHtml(helpText, Html.FROM_HTML_MODE_LEGACY));
         binding.instanceHelpTV.setMovementMethod(LinkMovementMethod.getInstance());
+        
         binding.addInstanceButton.setOnClickListener(v -> showAddItemDialog(requireContext()));
         binding.instances.setLayoutManager(new LinearLayoutManager(requireContext()));
 

--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -5,6 +5,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.InputType;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -84,8 +88,22 @@ public class PeertubeInstanceListFragment extends Fragment {
                               @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(rootView, savedInstanceState);
 
-        binding.instanceHelpTV.setText(getString(R.string.peertube_instance_url_help,
-                getString(R.string.peertube_instance_list_url)));
+        final String instanceListUrl = getString(R.string.peertube_instance_list_url);
+        final String helpText = getString(R.string.peertube_instance_url_help, instanceListUrl);
+        final SpannableString spannableString = new SpannableString(helpText);
+        
+        final int urlStart = helpText.indexOf(instanceListUrl);
+        if (urlStart != -1) {
+            spannableString.setSpan(
+                    new URLSpan(instanceListUrl),
+                    urlStart,
+                    urlStart + instanceListUrl.length(),
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            );
+        }
+        
+        binding.instanceHelpTV.setText(spannableString);
+        binding.instanceHelpTV.setMovementMethod(LinkMovementMethod.getInstance());
         binding.addInstanceButton.setOnClickListener(v -> showAddItemDialog(requireContext()));
         binding.instances.setLayoutManager(new LinearLayoutManager(requireContext()));
 

--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -4,9 +4,10 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.InputType;
 import android.text.method.LinkMovementMethod;
+
+import androidx.core.text.HtmlCompat;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -89,7 +90,8 @@ public class PeertubeInstanceListFragment extends Fragment {
         final String instanceListUrl = getString(R.string.peertube_instance_list_url);
         final String helpText = getString(R.string.peertube_instance_url_help,
                 "<a href=\"" + instanceListUrl + "\">" + instanceListUrl + "</a>");
-        binding.instanceHelpTV.setText(Html.fromHtml(helpText, Html.FROM_HTML_MODE_LEGACY));
+        binding.instanceHelpTV.setText(HtmlCompat.fromHtml(helpText,
+                HtmlCompat.FROM_HTML_MODE_LEGACY));
         binding.instanceHelpTV.setMovementMethod(LinkMovementMethod.getInstance());
 
         binding.addInstanceButton.setOnClickListener(v -> showAddItemDialog(requireContext()));

--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -91,7 +91,7 @@ public class PeertubeInstanceListFragment extends Fragment {
                 "<a href=\"" + instanceListUrl + "\">" + instanceListUrl + "</a>");
         binding.instanceHelpTV.setText(Html.fromHtml(helpText, Html.FROM_HTML_MODE_LEGACY));
         binding.instanceHelpTV.setMovementMethod(LinkMovementMethod.getInstance());
-        
+
         binding.addInstanceButton.setOnClickListener(v -> showAddItemDialog(requireContext()));
         binding.instances.setLayoutManager(new LinearLayoutManager(requireContext()));
 

--- a/app/src/main/res/layout/fragment_instance_list.xml
+++ b/app/src/main/res/layout/fragment_instance_list.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="15dp"
-        android:autoLink="web"
         android:text="@string/peertube_instance_url_help" />
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

This pull request updates the PeerTube instance help text in the settings to make the instance list URL clickable and improves its display. The change enhances user experience by allowing users to directly access the instance list from the help text.

#### Fixes the following issue(s)

- Fix clicking on instance list link not working which is for help in peertube instance selection given in settings.

#### APK testing

The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [ ] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
