### PR TITLE
[wip] Support cover art and other metadata in mp4 and opus downloads

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/OggFromWebMWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/OggFromWebMWriter.java
@@ -303,9 +303,7 @@ public class OggFromWebMWriter implements Closeable {
 
             if (DEBUG) {
                 Log.d("OggFromWebMWriter", "Creating metadata header with this data:");
-                metadata.forEach(p -> {
-                    Log.d("OggFromWebMWriter", p.first + "=" + p.second);
-                });
+                metadata.forEach(p -> Log.d("OggFromWebMWriter", p.first + "=" + p.second));
             }
 
             return makeOpusTagsHeader(metadata);

--- a/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.kt
@@ -185,7 +185,7 @@ object ImageStrategy {
     fun dbUrlToImageList(url: String?): List<Image> {
         return when (url) {
             null -> listOf()
-            else -> listOf(Image(url, -1, -1, ResolutionLevel.UNKNOWN))
+            else -> listOf(Image(url, Image.HEIGHT_UNKNOWN, Image.WIDTH_UNKNOWN, ResolutionLevel.UNKNOWN))
         }
     }
 }

--- a/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
@@ -30,7 +30,7 @@ class M4aNoDash extends Postprocessing {
 
     @Override
     int process(SharpStream out, SharpStream... sources) throws IOException {
-        Mp4FromDashWriter muxer = new Mp4FromDashWriter(sources[0]);
+        Mp4FromDashWriter muxer = new Mp4FromDashWriter(this.streamInfo, sources[0]);
         muxer.setMainBrand(0x4D344120);// binary string "M4A "
         muxer.parseSources();
         muxer.selectTracks(0);

--- a/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
@@ -30,7 +30,8 @@ class M4aNoDash extends Postprocessing {
 
     @Override
     int process(SharpStream out, SharpStream... sources) throws IOException {
-        Mp4FromDashWriter muxer = new Mp4FromDashWriter(this.streamInfo, sources[0]);
+        Mp4FromDashWriter muxer = new Mp4FromDashWriter(
+                this.streamInfo, this.thumbnail, sources[0]);
         muxer.setMainBrand(0x4D344120);// binary string "M4A "
         muxer.parseSources();
         muxer.selectTracks(0);

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
@@ -16,7 +16,7 @@ class Mp4FromDashMuxer extends Postprocessing {
 
     @Override
     int process(SharpStream out, SharpStream... sources) throws IOException {
-        Mp4FromDashWriter muxer = new Mp4FromDashWriter(sources);
+        Mp4FromDashWriter muxer = new Mp4FromDashWriter(this.streamInfo, sources);
         muxer.parseSources();
         muxer.selectTracks(0, 0);
         muxer.build(out);

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
@@ -16,7 +16,7 @@ class Mp4FromDashMuxer extends Postprocessing {
 
     @Override
     int process(SharpStream out, SharpStream... sources) throws IOException {
-        Mp4FromDashWriter muxer = new Mp4FromDashWriter(this.streamInfo, sources);
+        Mp4FromDashWriter muxer = new Mp4FromDashWriter(this.streamInfo, this.thumbnail, sources);
         muxer.parseSources();
         muxer.selectTracks(0, 0);
         muxer.build(out);

--- a/app/src/main/java/us/shandian/giga/postprocessing/OggFromWebmDemuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/OggFromWebmDemuxer.java
@@ -34,7 +34,8 @@ class OggFromWebmDemuxer extends Postprocessing {
 
     @Override
     int process(SharpStream out, @NonNull SharpStream... sources) throws IOException {
-        OggFromWebMWriter demuxer = new OggFromWebMWriter(sources[0], out, streamInfo);
+        OggFromWebMWriter demuxer = new OggFromWebMWriter(
+                sources[0], out, streamInfo, thumbnail);
         demuxer.parseSource();
         demuxer.selectTrack(0);
         demuxer.build();

--- a/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.streams.io.SharpStream;
@@ -33,7 +34,7 @@ public abstract class Postprocessing implements Serializable {
     public transient static final String ALGORITHM_OGG_FROM_WEBM_DEMUXER = "webm-ogg-d";
 
     public static Postprocessing getAlgorithm(@NonNull String algorithmName, String[] args,
-                                              StreamInfo streamInfo) {
+                                              @NonNull StreamInfo streamInfo) {
         Postprocessing instance;
 
         switch (algorithmName) {
@@ -80,7 +81,18 @@ public abstract class Postprocessing implements Serializable {
     private final String name;
 
     private String[] args;
+
+    /**
+     * StreamInfo object related to the current download
+     */
+    @NonNull
     protected StreamInfo streamInfo;
+
+    /**
+     * The thumbnail / cover art bitmap associated with the current download.
+     * May be null.
+     */
+    @Nullable
     protected Bitmap thumbnail;
 
     private transient DownloadMission mission;

--- a/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
@@ -1,5 +1,6 @@
 package us.shandian.giga.postprocessing;
 
+import android.graphics.Bitmap;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -80,6 +81,7 @@ public abstract class Postprocessing implements Serializable {
 
     private String[] args;
     protected StreamInfo streamInfo;
+    protected Bitmap thumbnail;
 
     private transient DownloadMission mission;
 
@@ -105,6 +107,10 @@ public abstract class Postprocessing implements Serializable {
                 // nothing to do
             }
         }
+    }
+
+    public void setThumbnail(Bitmap thumbnail) {
+        this.thumbnail = thumbnail;
     }
 
 


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR adds support for thumbnails / cover arts for downloaded mp4 and opus/ogg files.
Metadata support (artist, name, date) for mp4 files is also added. Side note: mp4/MPEG-4 sucks implementation wise because there are a lot of magic bytes.

#### To do
⚠️  This PR is in an early stage as is supposed to be used for testing only atm.

- [ ] Changes need to be tested with different players and devices
- [ ] mp4 changes are not trivial and need to be tested in detail
- [ ] fetch cover art properly and use reliable async implementation. 
- [ ] documentation
- [ ] decide whether the user should be able to turn off metadata completely.

#### Before/After Screenshots/Screen Record
- Before:
- After:

#### Relies on the following changes

#### APK testing
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
