### PR TITLE
Fix playlist item dragging video to only neighbor positions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -768,9 +768,15 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                 final boolean isSwapped = itemListAdapter.swapItems(sourceIndex, targetIndex);
                 if (isSwapped) {
                     debounceSaver.setHasChangesToSave();
-                    saveImmediate();
                 }
                 return isSwapped;
+            }
+
+            @Override
+            public void clearView(@NonNull final RecyclerView recyclerView,
+                                  @NonNull final RecyclerView.ViewHolder viewHolder) {
+                super.clearView(recyclerView, viewHolder);
+                saveImmediate();
             }
 
             @Override


### PR DESCRIPTION
Call `saveImmediate` only after used actually dropped item instead of every time View is updated which happens several times to show user a feedback where item would be moved

#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

- Fix playlist item dragging video to only neighbor positions

- Call `saveImmediate` only after used actually dropped item instead of every time View is updated which happens several times to show user a feedback where item would be moved

#### Fixes the following issue(s)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
