### PR TITLE
Fix audio ducking issue by using Android's automatic audio focus management

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -1,37 +1,26 @@
 package org.schabi.newpipe.player.helper;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
 import android.media.audiofx.AudioEffect;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
-import androidx.media.AudioFocusRequestCompat;
 import androidx.media.AudioManagerCompat;
 
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.analytics.AnalyticsListener;
 
-public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, AnalyticsListener {
+public class AudioReactor implements AnalyticsListener {
 
     private static final String TAG = "AudioFocusReactor";
 
-    private static final int DUCK_DURATION = 1500;
-    private static final float DUCK_AUDIO_TO = .2f;
-
-    private static final int FOCUS_GAIN_TYPE = AudioManagerCompat.AUDIOFOCUS_GAIN;
     private static final int STREAM_TYPE = AudioManager.STREAM_MUSIC;
 
     private final ExoPlayer player;
     private final Context context;
     private final AudioManager audioManager;
-
-    private final AudioFocusRequestCompat request;
 
     public AudioReactor(@NonNull final Context context,
                         @NonNull final ExoPlayer player) {
@@ -39,16 +28,9 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
         this.context = context;
         this.audioManager = ContextCompat.getSystemService(context, AudioManager.class);
         player.addAnalyticsListener(this);
-
-        request = new AudioFocusRequestCompat.Builder(FOCUS_GAIN_TYPE)
-                //.setAcceptsDelayedFocusGain(true)
-                .setWillPauseWhenDucked(true)
-                .setOnAudioFocusChangeListener(this)
-                .build();
     }
 
     public void dispose() {
-        abandonAudioFocus();
         player.removeAnalyticsListener(this);
         notifyAudioSessionUpdate(false, player.getAudioSessionId());
     }
@@ -56,14 +38,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
     /*//////////////////////////////////////////////////////////////////////////
     // Audio Manager
     //////////////////////////////////////////////////////////////////////////*/
-
-    public void requestAudioFocus() {
-        AudioManagerCompat.requestAudioFocus(audioManager, request);
-    }
-
-    public void abandonAudioFocus() {
-        AudioManagerCompat.abandonAudioFocusRequest(audioManager, request);
-    }
 
     public int getVolume() {
         return audioManager.getStreamVolume(STREAM_TYPE);
@@ -75,73 +49,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
 
     public int getMaxVolume() {
         return AudioManagerCompat.getStreamMaxVolume(audioManager, STREAM_TYPE);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // AudioFocus
-    //////////////////////////////////////////////////////////////////////////*/
-
-    @Override
-    public void onAudioFocusChange(final int focusChange) {
-        Log.d(TAG, "onAudioFocusChange() called with: focusChange = [" + focusChange + "]");
-        switch (focusChange) {
-            case AudioManager.AUDIOFOCUS_GAIN:
-                onAudioFocusGain();
-                break;
-            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                onAudioFocusLossCanDuck();
-                break;
-            case AudioManager.AUDIOFOCUS_LOSS:
-            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                onAudioFocusLoss();
-                break;
-        }
-    }
-
-    private void onAudioFocusGain() {
-        Log.d(TAG, "onAudioFocusGain() called");
-        player.setVolume(DUCK_AUDIO_TO);
-        animateAudio(DUCK_AUDIO_TO, 1.0f);
-
-        if (PlayerHelper.isResumeAfterAudioFocusGain(context)) {
-            player.play();
-        }
-    }
-
-    private void onAudioFocusLoss() {
-        Log.d(TAG, "onAudioFocusLoss() called");
-        player.pause();
-    }
-
-    private void onAudioFocusLossCanDuck() {
-        Log.d(TAG, "onAudioFocusLossCanDuck() called");
-        // Set the volume to 1/10 on ducking
-        player.setVolume(DUCK_AUDIO_TO);
-    }
-
-    private void animateAudio(final float from, final float to) {
-        final ValueAnimator valueAnimator = new ValueAnimator();
-        valueAnimator.setFloatValues(from, to);
-        valueAnimator.setDuration(AudioReactor.DUCK_DURATION);
-        valueAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationStart(final Animator animation) {
-                player.setVolume(from);
-            }
-
-            @Override
-            public void onAnimationCancel(final Animator animation) {
-                player.setVolume(to);
-            }
-
-            @Override
-            public void onAnimationEnd(final Animator animation) {
-                player.setVolume(to);
-            }
-        });
-        valueAnimator.addUpdateListener(animation ->
-                player.setVolume(((float) animation.getAnimatedValue())));
-        valueAnimator.start();
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

Fix audio ducking issue by using Android's automatic audio focus management

Previously, manual audio focus handling caused volume to not be restored after transient ducking on some devices.

This change removes manual AudioFocusRequest management and relies on ExoPlayer's built-in audio focus handling (handleAudioFocus=true), which properly manages automatic ducking as recommended in: https://developer.android.com/media/optimize/audio-focus#automatic-ducking

#### Fixes the following issue(s)

- Fixes - Issue with volume after interruption

#### APK testing

<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).