### PR TITLE
Fix inconsistency in getQuantity and add docs

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/Localization.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Localization.java
@@ -426,12 +426,24 @@ public final class Localization {
         return new BigDecimal(value).setScale(scale, RoundingMode.HALF_UP).doubleValue();
     }
 
+    /**
+     * A wrapper around {@code context.getResources().getQuantityString()} with some safeguard.
+     *
+     * @param context the Android context
+     * @param pluralId the ID of the plural resource
+     * @param zeroCaseStringId the resource ID of the string to use in case {@code count=0},
+     *                         or 0 if the plural resource should be used in the zero case too
+     * @param count the number that should be used to pick the correct plural form
+     * @param formattedCount the formatting parameter to substitute inside the plural resource,
+     *                       ideally just {@code count} converted to string
+     * @return the formatted string with the correct pluralization
+     */
     private static String getQuantity(@NonNull final Context context,
                                       @PluralsRes final int pluralId,
                                       @StringRes final int zeroCaseStringId,
                                       final long count,
                                       final String formattedCount) {
-        if (count == 0) {
+        if (count == 0 && zeroCaseStringId != 0) {
             return context.getString(zeroCaseStringId);
         }
 


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR

`getQuantity()` was being called in a couple of places with `zeroCaseStringId=0`, but that wasn't documented anywhere, and if `count==0` then `getString(zeroCaseStringId /* == 0 */)` would be returned which doesn't make sense. So now `getQuantity` will use the normal plural resource instead if both `count == 0` and `zeroCaseStringId == 0`.  I don't think this ever caused issues anywhere, because `count` was never `0` when those functions were called with `zeroCaseStringId == 0`, but still let's be sure.


#### APK testing

The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
