### PR TITLE
Show playtime and view count in feed items

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
@@ -11,6 +11,7 @@ import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Maybe
 import java.time.OffsetDateTime
 import org.schabi.newpipe.database.BasicDAO
+import org.schabi.newpipe.database.stream.StreamWithState
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity.Companion.STREAM_ID
 import org.schabi.newpipe.extractor.stream.StreamType
@@ -29,6 +30,17 @@ abstract class StreamDAO : BasicDAO<StreamEntity> {
 
     @Query("SELECT * FROM streams WHERE url = :url AND service_id = :serviceId")
     abstract fun getStream(serviceId: Long, url: String): Maybe<StreamEntity>
+
+    @Query(
+        """
+        SELECT s.*, sst.progress_time
+        FROM streams s
+        LEFT JOIN stream_state sst ON s.uid = sst.stream_id
+        WHERE s.url = :url AND s.service_id = :serviceId
+        LIMIT 1
+        """
+    )
+    abstract fun getStreamWithState(serviceId: Int, url: String): Maybe<StreamWithState>
 
     @Query("UPDATE streams SET uploader_url = :uploaderUrl WHERE url = :url AND service_id = :serviceId")
     abstract fun setUploaderUrl(serviceId: Long, url: String, uploaderUrl: String): Completable

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.kt
@@ -44,6 +44,7 @@ import androidx.core.net.toUri
 import androidx.core.os.postDelayed
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
 import coil3.util.CoilUtils
 import com.evernote.android.state.State
@@ -90,6 +91,7 @@ import org.schabi.newpipe.ktx.AnimationType
 import org.schabi.newpipe.ktx.animate
 import org.schabi.newpipe.ktx.animateRotation
 import org.schabi.newpipe.local.dialog.PlaylistDialog
+import org.schabi.newpipe.local.feed.StreamUpdateViewModel
 import org.schabi.newpipe.local.history.HistoryRecordManager
 import org.schabi.newpipe.local.playlist.LocalPlaylistFragment
 import org.schabi.newpipe.player.Player
@@ -203,6 +205,7 @@ class VideoDetailFragment :
     private var currentWorker: Disposable? = null
     private val disposables = CompositeDisposable()
     private var positionSubscriber: Disposable? = null
+    private var streamUpdateViewModel: StreamUpdateViewModel? = null
 
     /*//////////////////////////////////////////////////////////////////////////
     // Service management
@@ -580,6 +583,8 @@ class VideoDetailFragment :
     // called from onViewCreated in {@link BaseFragment#onViewCreated}
     override fun initViews(rootView: View?, savedInstanceState: Bundle?) {
         super.initViews(rootView, savedInstanceState)
+
+        streamUpdateViewModel = ViewModelProvider(requireActivity())[StreamUpdateViewModel::class]
 
         pageAdapter = TabAdapter(getChildFragmentManager())
         binding.viewPager.setAdapter(pageAdapter)
@@ -1531,6 +1536,9 @@ class VideoDetailFragment :
         binding.detailThumbnailPlayButton.setImageResource(
             if (hasVideoStreams) R.drawable.ic_play_arrow_shadow else R.drawable.ic_headset_shadow
         )
+
+        // Notify FeedFragment that this stream's data (including view count) has been updated
+        streamUpdateViewModel?.notifyStreamInfoUpdated(info.serviceId, info.url)
     }
 
     private fun displayUploaderAsSubChannel(info: StreamInfo) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
@@ -54,6 +54,8 @@ class FeedDatabaseManager(context: Context) {
         )
     }
 
+    fun getStreamWithState(serviceId: Int, url: String): Maybe<StreamWithState> = streamTable.getStreamWithState(serviceId, url)
+
     fun outdatedSubscriptions(outdatedThreshold: OffsetDateTime) = feedTable.getAllOutdated(outdatedThreshold)
 
     fun outdatedSubscriptionsWithNotificationMode(

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -109,6 +109,8 @@ class FeedFragment : BaseStateFragment<FeedState>() {
 
     private var lastNewItemsCount = 0
 
+    private lateinit var streamUpdateViewModel: StreamUpdateViewModel
+
     init {
         setHasOptionsMenu(true)
     }
@@ -142,6 +144,20 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         val factory = FeedViewModel.getFactory(requireContext(), groupId)
         viewModel = ViewModelProvider(this, factory)[FeedViewModel::class.java]
         viewModel.stateLiveData.observe(viewLifecycleOwner) { it?.let(::handleResult) }
+
+        // Activity-scoped ViewModel shared with VideoDetailFragment
+        streamUpdateViewModel = ViewModelProvider(requireActivity())[StreamUpdateViewModel::class.java]
+
+        streamUpdateViewModel.updatedStream.observe(viewLifecycleOwner) { (serviceId, url) ->
+            refreshFeedItem(serviceId, url)
+        }
+
+        disposables.add(
+            StreamUpdateViewModel.globalProgressBus
+                .onBackpressureLatest()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ (serviceId, url) -> refreshFeedItem(serviceId, url) }, { })
+        )
 
         groupAdapter = GroupieAdapter().apply {
             setOnItemClickListener(listenerStreamItem)
@@ -182,6 +198,31 @@ class FeedFragment : BaseStateFragment<FeedState>() {
                 handleResult(viewModel.stateLiveData.value!!)
             }
         }
+    }
+
+    /**
+     * Re-queries the DB for a single stream identified by [serviceId] + [url] and updates
+     * only that item in the adapter (view count + watch progress), without triggering a full
+     * list reload.
+     */
+    private fun refreshFeedItem(serviceId: Int, url: String) {
+        disposables.add(
+            viewModel.refreshStreamWithState(serviceId, url)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ updatedStreamWithState ->
+                    for (i in 0 until groupAdapter.itemCount) {
+                        val item = groupAdapter.getItem(i)
+                        if (item is StreamItem &&
+                            item.streamWithState.stream.url == url &&
+                            item.streamWithState.stream.serviceId == serviceId
+                        ) {
+                            item.streamWithState = updatedStreamWithState
+                            groupAdapter.notifyItemChanged(i, StreamItem.UPDATE_STREAM_DATA)
+                            break
+                        }
+                    }
+                }, { /* ignore — feed refreshes on next full load */ })
+        )
     }
 
     private fun setupListViewMode() {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.preference.PreferenceManager
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.functions.Function6
 import io.reactivex.rxjava3.processors.BehaviorProcessor
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -152,6 +153,14 @@ class FeedViewModel(
     }
 
     fun getShowFutureItemsFromPreferences() = getShowFutureItemsFromPreferences(application)
+
+    /**
+     * Returns a fresh [StreamWithState] for a single stream identified by [serviceId] and [url],
+     * reading the latest view count and watch progress directly from the database.
+     * Executes on the IO scheduler.
+     */
+    fun refreshStreamWithState(serviceId: Int, url: String): Maybe<StreamWithState> = feedDatabaseManager.getStreamWithState(serviceId, url)
+        .subscribeOn(Schedulers.io())
 
     companion object {
         private fun getShowPlayedItemsFromPreferences(context: Context) = PreferenceManager.getDefaultSharedPreferences(context)

--- a/app/src/main/java/org/schabi/newpipe/local/feed/StreamUpdateViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/StreamUpdateViewModel.kt
@@ -1,0 +1,49 @@
+package org.schabi.newpipe.local.feed
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import io.reactivex.rxjava3.processors.PublishProcessor
+
+/**
+ * Activity-scoped ViewModel used as a message bus between
+ * [VideoDetailFragment][org.schabi.newpipe.fragments.detail.VideoDetailFragment]
+ * and [FeedFragment].
+ *
+ * Two trigger points post here:
+ * 1. `VideoDetailFragment.handleResult` — stream info (view count) written to DB.
+ * 2. `HistoryRecordManager.saveStreamState` — watch progress written to DB via [globalProgressBus].
+ *
+ * [FeedFragment] observes [updatedStream] and re-queries only the affected item from the DB.
+ */
+class StreamUpdateViewModel : ViewModel() {
+
+    private val _updatedStream = MutableLiveData<Pair<Int, String>>()
+
+    /** Emits (serviceId, url) whenever a stream's DB record (view count or progress) is updated. */
+    val updatedStream: LiveData<Pair<Int, String>> = _updatedStream
+
+    /** Called by VideoDetailFragment after the stream info (including view count) is stored. */
+    fun notifyStreamInfoUpdated(serviceId: Int, url: String) {
+        _updatedStream.postValue(Pair(serviceId, url))
+    }
+
+    companion object {
+        /**
+         * Process-wide bus used by [org.schabi.newpipe.local.history.HistoryRecordManager] (which
+         * has no Activity context) to publish progress-save events.
+         * [FeedFragment] subscribes to this bus directly in [FeedFragment.onViewCreated].
+         */
+        @JvmStatic
+        val globalProgressBus: PublishProcessor<Pair<Int, String>> = PublishProcessor.create()
+
+        /**
+         * Called by [org.schabi.newpipe.local.history.HistoryRecordManager] every time it saves playback progress.
+         * Safe to call from any thread.
+         */
+        @JvmStatic
+        fun postProgressUpdate(serviceId: Int, url: String) {
+            globalProgressBus.onNext(Pair(serviceId, url))
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
@@ -24,15 +24,16 @@ import org.schabi.newpipe.util.StreamTypeUtil
 import org.schabi.newpipe.util.image.CoilHelper
 
 data class StreamItem(
-    val streamWithState: StreamWithState,
+    var streamWithState: StreamWithState,
     var itemVersion: ItemVersion = ItemVersion.NORMAL
 ) : BindableItem<ListStreamItemBinding>() {
     companion object {
         const val UPDATE_RELATIVE_TIME = 1
+        const val UPDATE_STREAM_DATA = 2
     }
 
-    private val stream: StreamEntity = streamWithState.stream
-    private val stateProgressTime: Long? = streamWithState.stateProgressMillis
+    private val stream: StreamEntity get() = streamWithState.stream
+    private val stateProgressTime: Long? get() = streamWithState.stateProgressMillis
 
     /**
      * Will be executed at the end of the [StreamItem.bind] (with (ListStreamItemBinding,Int)).
@@ -62,6 +63,27 @@ data class StreamItem(
             return
         }
 
+        if (payloads.contains(UPDATE_STREAM_DATA)) {
+            // Rebind only the fields that may have changed: view count and watch progress
+            if (itemVersion != ItemVersion.MINI) {
+                viewBinding.itemAdditionalDetails.text =
+                    getStreamInfoDetailLine(viewBinding.itemAdditionalDetails.context)
+            }
+            if (stream.duration > 0) {
+                val progress = stateProgressTime
+                if (progress != null) {
+                    viewBinding.itemProgressView.visibility = View.VISIBLE
+                    viewBinding.itemProgressView.max = stream.duration.toInt()
+                    viewBinding.itemProgressView.progress =
+                        TimeUnit.MILLISECONDS.toSeconds(progress).toInt()
+                } else {
+                    viewBinding.itemProgressView.visibility = View.GONE
+                }
+            }
+            execBindEnd?.accept(viewBinding)
+            return
+        }
+
         super.bind(viewBinding, position, payloads)
     }
 
@@ -82,7 +104,9 @@ data class StreamItem(
             if (stateProgressTime != null) {
                 viewBinding.itemProgressView.visibility = View.VISIBLE
                 viewBinding.itemProgressView.max = stream.duration.toInt()
-                viewBinding.itemProgressView.progress = TimeUnit.MILLISECONDS.toSeconds(stateProgressTime).toInt()
+                viewBinding.itemProgressView.progress = TimeUnit.MILLISECONDS.toSeconds(
+                    stateProgressTime!!
+                ).toInt()
             } else {
                 viewBinding.itemProgressView.visibility = View.GONE
             }

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryRecordManager.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryRecordManager.java
@@ -47,6 +47,7 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.local.feed.FeedViewModel;
+import org.schabi.newpipe.local.feed.StreamUpdateViewModel;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
 import java.time.OffsetDateTime;
@@ -243,12 +244,15 @@ public class HistoryRecordManager {
 
     public Completable saveStreamState(@NonNull final StreamInfo info, final long progressMillis) {
         return Completable.fromAction(() -> database.runInTransaction(() -> {
-            final long streamId = streamTable.upsert(new StreamEntity(info));
-            final var state = new StreamStateEntity(streamId, progressMillis);
-            if (state.isValid(info.getDuration())) {
-                streamStateTable.upsert(state);
-            }
-        })).subscribeOn(Schedulers.io());
+                    final long streamId = streamTable.upsert(new StreamEntity(info));
+                    final var state = new StreamStateEntity(streamId, progressMillis);
+                    if (state.isValid(info.getDuration())) {
+                        streamStateTable.upsert(state);
+                    }
+                })).subscribeOn(Schedulers.io())
+                .doOnComplete(() -> StreamUpdateViewModel.postProgressUpdate(
+                        info.getServiceId(), info.getUrl()
+                ));
     }
 
     public Maybe<StreamStateEntity> loadStreamState(final InfoItem info) {


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Update the playtime and view count on the feed items from the video player fragment. When video is opened, it loads the view count which is updated on the feed item. Anytime the video is paused or seek forward/backward or closed, the feed item is updated to show the latest play time.

#### Before/After Screenshots/Screen Record


#### Relies on the following changes

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [ ] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [ ] I tested the changes using an emulator or a physical device.
