### PR TITLE
Fix video playback when exiting popup to main screen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1143,7 +1143,8 @@ public final class VideoDetailFragment
      * = false}, hence preventing it from going directly fullscreen.
      */
     public void openVideoPlayerAutoFullscreen() {
-        openVideoPlayer(forceFullscreen || PlayerHelper.isStartMainPlayerFullscreenEnabled(requireContext()));
+        openVideoPlayer(forceFullscreen
+                || PlayerHelper.isStartMainPlayerFullscreenEnabled(requireContext()));
         forceFullscreen = false;
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -205,6 +205,7 @@ public final class VideoDetailFragment
     int lastStableBottomSheetState = BottomSheetBehavior.STATE_EXPANDED;
     @State
     protected boolean autoPlayEnabled = true;
+    private boolean forceFullscreen = false;
 
     @Nullable
     private StreamInfo currentInfo = null;
@@ -877,7 +878,7 @@ public final class VideoDetailFragment
                             }
                         }
 
-                        if (isAutoplayEnabled()) {
+                        if (isAutoplayEnabled() || forceFullscreen) {
                             openVideoPlayerAutoFullscreen();
                         }
                     }
@@ -1142,7 +1143,18 @@ public final class VideoDetailFragment
      * = false}, hence preventing it from going directly fullscreen.
      */
     public void openVideoPlayerAutoFullscreen() {
-        openVideoPlayer(PlayerHelper.isStartMainPlayerFullscreenEnabled(requireContext()));
+        openVideoPlayer(forceFullscreen || PlayerHelper.isStartMainPlayerFullscreenEnabled(requireContext()));
+        forceFullscreen = false;
+    }
+
+    public void setForceFullscreen(final boolean force) {
+        this.forceFullscreen = force;
+    }
+
+    //return the URL of the stream currently handled by this fragment.
+    @Nullable
+    public String getUrl() {
+        return url;
     }
 
     private void openNormalBackgroundPlayer(final boolean append) {

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.util;
 
 import static android.text.TextUtils.isEmpty;
+import android.text.TextUtils;
 import static org.schabi.newpipe.util.ListHelper.getUrlAndNonTorrentStreams;
 
 import android.annotation.SuppressLint;
@@ -430,13 +431,16 @@ public final class NavigationHelper {
         final RunnableWithVideoDetailFragment onVideoDetailFragmentReady = detailFragment -> {
             expandMainPlayer(detailFragment.requireActivity());
             detailFragment.setAutoPlay(autoPlay);
-            if (switchingPlayers) {
+            if (switchingPlayers && TextUtils.equals(detailFragment.getUrl(), url)) {
                 // Situation when user switches from players to main player. All needed data is
                 // here, we can start watching (assuming newQueue equals playQueue).
                 // Starting directly in fullscreen if the previous player type was popup.
                 detailFragment.openVideoPlayer(playerType == PlayerType.POPUP
                         || PlayerHelper.isStartMainPlayerFullscreenEnabled(context));
             } else {
+                if (switchingPlayers && playerType == PlayerType.POPUP) {
+                    detailFragment.setForceFullscreen(true);
+                }
                 detailFragment.selectAndLoadVideo(serviceId, url, title, playQueue);
             }
             detailFragment.scrollToTop();


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

- The fix makes transitions from the popup player to the main screen seamless 
- The popup video now plays in the attached view as expected . (Earlier, the video opened in the background was playing instead).

#### Before/After Screenshots/Screen Record

- Before: 

https://github.com/user-attachments/assets/f481c0e4-5ddd-4ca6-a60c-2801a2e372c6

--- 

- After:

https://github.com/user-attachments/assets/fee03649-8fc9-46bd-9d5a-ff60e1bd88b4

#### Fixes the following issue(s)

- Fixes: Switching to main from popup player shows wrong video

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [ ] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [ ] I tested the changes using an emulator or a physical device.
