### PR TITLE
Filter subscriptions by channel group

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/feed/model/FeedGroupEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/feed/model/FeedGroupEntity.kt
@@ -35,5 +35,6 @@ data class FeedGroupEntity(
         const val SORT_ORDER = "sort_order"
 
         const val GROUP_ALL_ID = -1L
+        const val GROUP_UNGROUPED_ID = -2L
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
@@ -68,6 +68,18 @@ abstract class SubscriptionDAO : BasicDAO<SubscriptionEntity> {
         filter: String
     ): Flowable<List<SubscriptionEntity>>
 
+    @RewriteQueriesToDropUnusedColumns
+    @Query(
+        """
+        SELECT * FROM subscriptions s
+        INNER JOIN feed_group_subscription_join fgs
+        ON s.uid = fgs.subscription_id
+        WHERE fgs.group_id = :groupId
+        ORDER BY name COLLATE NOCASE ASC
+        """
+    )
+    abstract fun getSubscriptionsForGroup(groupId: Long): Flowable<List<SubscriptionEntity>>
+
     @Query("SELECT * FROM subscriptions WHERE url LIKE :url AND service_id = :serviceId")
     abstract fun getSubscriptionFlowable(serviceId: Int, url: String): Flowable<List<SubscriptionEntity>>
 

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
@@ -80,6 +80,18 @@ abstract class SubscriptionDAO : BasicDAO<SubscriptionEntity> {
     )
     abstract fun getSubscriptionsForGroup(groupId: Long): Flowable<List<SubscriptionEntity>>
 
+    @RewriteQueriesToDropUnusedColumns
+    @Query(
+        """
+        SELECT * FROM subscriptions s
+        LEFT JOIN feed_group_subscription_join fgs
+        ON s.uid = fgs.subscription_id
+        WHERE fgs.subscription_id IS NULL
+        ORDER BY name COLLATE NOCASE ASC
+        """
+    )
+    abstract fun getSubscriptionsNotInAnyGroup(): Flowable<List<SubscriptionEntity>>
+
     @Query("SELECT * FROM subscriptions WHERE url LIKE :url AND service_id = :serviceId")
     abstract fun getSubscriptionFlowable(serviceId: Int, url: String): Flowable<List<SubscriptionEntity>>
 

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
@@ -80,13 +80,13 @@ abstract class SubscriptionDAO : BasicDAO<SubscriptionEntity> {
     )
     abstract fun getSubscriptionsForGroup(groupId: Long): Flowable<List<SubscriptionEntity>>
 
-    @RewriteQueriesToDropUnusedColumns
     @Query(
         """
         SELECT * FROM subscriptions s
-        LEFT JOIN feed_group_subscription_join fgs
-        ON s.uid = fgs.subscription_id
-        WHERE fgs.subscription_id IS NULL
+        WHERE NOT EXISTS (
+            SELECT 1 FROM feed_group_subscription_join fgs
+            WHERE fgs.subscription_id = s.uid
+        )
         ORDER BY name COLLATE NOCASE ASC
         """
     )

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -25,6 +25,7 @@ import com.xwray.groupie.viewbinding.GroupieViewHolder
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity.Companion.GROUP_ALL_ID
+import org.schabi.newpipe.database.feed.model.FeedGroupEntity.Companion.GROUP_UNGROUPED_ID
 import org.schabi.newpipe.databinding.DialogTitleBinding
 import org.schabi.newpipe.databinding.FeedItemCarouselBinding
 import org.schabi.newpipe.databinding.FragmentSubscriptionBinding
@@ -429,6 +430,11 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
                         }
                     }
                 )
+                if (currentListViewMode) {
+                    add(FeedGroupCardItem(GROUP_UNGROUPED_ID, getString(R.string.feed_group_ungrouped), FeedGroupIcon.PERSON, selectedId == GROUP_UNGROUPED_ID))
+                } else {
+                    add(FeedGroupCardGridItem(GROUP_UNGROUPED_ID, getString(R.string.feed_group_ungrouped), FeedGroupIcon.PERSON, selectedId == GROUP_UNGROUPED_ID))
+                }
             }
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -70,7 +70,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     private val subscriptionsSection = Section()
 
     private var currentGroups: List<Group> = emptyList()
-    private var currentListViewMode: Boolean = true
+    private var currentListViewMode: Boolean = true // updated from ViewModel after init
 
     @State
     @JvmField
@@ -208,6 +208,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         binding.emptyStateView.setEmptyStateComposable()
 
         viewModel = ViewModelProvider(this)[SubscriptionViewModel::class.java]
+        currentListViewMode = viewModel.getListViewMode()
         viewModel.stateLiveData.observe(viewLifecycleOwner) { it?.let(this::handleResult) }
         viewModel.feedGroupsLiveData.observe(viewLifecycleOwner) {
             it?.let { (groups, listViewMode) ->
@@ -248,26 +249,23 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
                     is FeedGroupCardGridItem -> item.name
                     else -> ""
                 }
-                if (groupId == viewModel.getSelectedGroupId()) {
+                if (groupId == viewModel.getSelectedGroupId() && groupId != GROUP_UNGROUPED_ID) {
                     NavigationHelper.openFeedFragment(fm, groupId, name)
                 } else {
                     viewModel.selectGroup(groupId)
                 }
             }
             carouselAdapter.setOnItemLongClickListener { item, _ ->
-                if ((item is FeedGroupCardItem && item.groupId == GROUP_ALL_ID) ||
-                    (item is FeedGroupCardGridItem && item.groupId == GROUP_ALL_ID)
-                ) {
+                val groupId = when (item) {
+                    is FeedGroupCardItem -> item.groupId
+                    is FeedGroupCardGridItem -> item.groupId
+                    else -> return@setOnItemLongClickListener false
+                }
+                if (groupId == GROUP_ALL_ID || groupId == GROUP_UNGROUPED_ID) {
                     return@setOnItemLongClickListener false
                 }
 
-                when (item) {
-                    is FeedGroupCardItem ->
-                        FeedGroupDialog.newInstance(item.groupId).show(fm, null)
-
-                    is FeedGroupCardGridItem ->
-                        FeedGroupDialog.newInstance(item.groupId).show(fm, null)
-                }
+                FeedGroupDialog.newInstance(groupId).show(fm, null)
                 return@setOnItemLongClickListener true
             }
 
@@ -402,10 +400,10 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     }
 
     private fun rebuildCarousel() {
-        val selectedId = viewModel.getSelectedGroupId()
         binding.itemsList.post {
             if (context == null) return@post
 
+            val selectedId = viewModel.getSelectedGroupId()
             feedGroupsCarousel.listViewMode = currentListViewMode
             feedGroupsSortMenuItem.showSortButton = currentGroups.size > 1
             feedGroupsSortMenuItem.listViewMode = currentListViewMode

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -68,6 +68,9 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     private lateinit var feedGroupsSortMenuItem: GroupsHeader
     private val subscriptionsSection = Section()
 
+    private var currentGroups: List<Group> = emptyList()
+    private var currentListViewMode: Boolean = true
+
     @State
     @JvmField
     var itemsListState: Parcelable? = null
@@ -210,6 +213,9 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
                 handleFeedGroups(groups, listViewMode)
             }
         }
+        viewModel.selectedGroupLiveData.observe(viewLifecycleOwner) {
+            rebuildCarousel()
+        }
 
         setupInitialLayout()
     }
@@ -219,18 +225,32 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
             carouselAdapter = GroupAdapter<GroupieViewHolder<FeedItemCarouselBinding>>()
 
             carouselAdapter.setOnItemClickListener { item, _ ->
-                when (item) {
-                    is FeedGroupCardItem ->
-                        NavigationHelper.openFeedFragment(fm, item.groupId, item.name)
+                val groupId = when (item) {
+                    is FeedGroupCardItem -> item.groupId
 
-                    is FeedGroupCardGridItem ->
-                        NavigationHelper.openFeedFragment(fm, item.groupId, item.name)
+                    is FeedGroupCardGridItem -> item.groupId
 
-                    is FeedGroupAddNewItem ->
+                    is FeedGroupAddNewItem -> {
                         FeedGroupDialog.newInstance().show(fm, null)
+                        return@setOnItemClickListener
+                    }
 
-                    is FeedGroupAddNewGridItem ->
+                    is FeedGroupAddNewGridItem -> {
                         FeedGroupDialog.newInstance().show(fm, null)
+                        return@setOnItemClickListener
+                    }
+
+                    else -> return@setOnItemClickListener
+                }
+                val name = when (item) {
+                    is FeedGroupCardItem -> item.name
+                    is FeedGroupCardGridItem -> item.name
+                    else -> ""
+                }
+                if (groupId == viewModel.getSelectedGroupId()) {
+                    NavigationHelper.openFeedFragment(fm, groupId, name)
+                } else {
+                    viewModel.selectGroup(groupId)
                 }
             }
             carouselAdapter.setOnItemLongClickListener { item, _ ->
@@ -375,31 +395,40 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
             feedGroupsCarousel.onRestoreInstanceState(feedGroupsCarouselState)
             feedGroupsCarouselState = null
         }
+        currentGroups = groups
+        currentListViewMode = listViewMode
+        rebuildCarousel()
+    }
 
+    private fun rebuildCarousel() {
+        val selectedId = viewModel.getSelectedGroupId()
         binding.itemsList.post {
-            if (context == null) {
-                // since this part was posted to the next UI cycle, the fragment might have been
-                // removed in the meantime
-                return@post
-            }
+            if (context == null) return@post
 
-            feedGroupsCarousel.listViewMode = listViewMode
-            feedGroupsSortMenuItem.showSortButton = groups.size > 1
-            feedGroupsSortMenuItem.listViewMode = listViewMode
+            feedGroupsCarousel.listViewMode = currentListViewMode
+            feedGroupsSortMenuItem.showSortButton = currentGroups.size > 1
+            feedGroupsSortMenuItem.listViewMode = currentListViewMode
             feedGroupsCarousel.notifyChanged(FeedGroupCarouselItem.PAYLOAD_UPDATE_LIST_VIEW_MODE)
             feedGroupsSortMenuItem.notifyChanged(GroupsHeader.PAYLOAD_UPDATE_ICONS)
 
-            // update items here to prevent flickering
             carouselAdapter.apply {
                 clear()
-                if (listViewMode) {
+                if (currentListViewMode) {
                     add(FeedGroupAddNewItem())
-                    add(FeedGroupCardItem(GROUP_ALL_ID, getString(R.string.all), FeedGroupIcon.WHATS_NEW))
+                    add(FeedGroupCardItem(GROUP_ALL_ID, getString(R.string.all), FeedGroupIcon.WHATS_NEW, selectedId == GROUP_ALL_ID))
                 } else {
                     add(FeedGroupAddNewGridItem())
-                    add(FeedGroupCardGridItem(GROUP_ALL_ID, getString(R.string.all), FeedGroupIcon.WHATS_NEW))
+                    add(FeedGroupCardGridItem(GROUP_ALL_ID, getString(R.string.all), FeedGroupIcon.WHATS_NEW, selectedId == GROUP_ALL_ID))
                 }
-                addAll(groups)
+                addAll(
+                    currentGroups.map { group ->
+                        when (group) {
+                            is FeedGroupCardItem -> group.copy(isSelected = group.groupId == selectedId)
+                            is FeedGroupCardGridItem -> group.copy(isSelected = group.groupId == selectedId)
+                            else -> group
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -46,6 +46,9 @@ class SubscriptionManager(context: Context) {
 
             showOnlyUngrouped -> subscriptionTable.getSubscriptionsOnlyUngrouped(currentGroupId)
 
+            currentGroupId != FeedGroupEntity.GROUP_ALL_ID ->
+                subscriptionTable.getSubscriptionsForGroup(currentGroupId)
+
             else -> subscriptionTable.getAll()
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -27,6 +27,12 @@ class SubscriptionManager(context: Context) {
     fun subscriptionTable(): SubscriptionDAO = subscriptionTable
     fun subscriptions() = subscriptionTable.getAll()
 
+    fun subscriptionsFilteredByGroup(groupId: Long): Flowable<List<SubscriptionEntity>> = when (groupId) {
+        FeedGroupEntity.GROUP_ALL_ID -> subscriptionTable.getAll()
+        FeedGroupEntity.GROUP_UNGROUPED_ID -> subscriptionTable.getSubscriptionsNotInAnyGroup()
+        else -> subscriptionTable.getSubscriptionsForGroup(groupId)
+    }
+
     fun getSubscriptions(
         currentGroupId: Long = FeedGroupEntity.GROUP_ALL_ID,
         filterQuery: String = "",
@@ -45,12 +51,6 @@ class SubscriptionManager(context: Context) {
             }
 
             showOnlyUngrouped -> subscriptionTable.getSubscriptionsOnlyUngrouped(currentGroupId)
-
-            currentGroupId == FeedGroupEntity.GROUP_UNGROUPED_ID ->
-                subscriptionTable.getSubscriptionsNotInAnyGroup()
-
-            currentGroupId != FeedGroupEntity.GROUP_ALL_ID ->
-                subscriptionTable.getSubscriptionsForGroup(currentGroupId)
 
             else -> subscriptionTable.getAll()
         }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -46,6 +46,9 @@ class SubscriptionManager(context: Context) {
 
             showOnlyUngrouped -> subscriptionTable.getSubscriptionsOnlyUngrouped(currentGroupId)
 
+            currentGroupId == FeedGroupEntity.GROUP_UNGROUPED_ID ->
+                subscriptionTable.getSubscriptionsNotInAnyGroup()
+
             currentGroupId != FeedGroupEntity.GROUP_ALL_ID ->
                 subscriptionTable.getSubscriptionsForGroup(currentGroupId)
 

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt
@@ -60,7 +60,7 @@ class SubscriptionViewModel(application: Application) : AndroidViewModel(applica
 
     private var stateItemsDisposable = selectedGroupId
         .switchMap { groupId ->
-            subscriptionManager.getSubscriptions(groupId).subscribeOn(Schedulers.io())
+            subscriptionManager.subscriptionsFilteredByGroup(groupId).subscribeOn(Schedulers.io())
         }
         .throttleLatest(DEFAULT_THROTTLE_TIMEOUT, TimeUnit.MILLISECONDS)
         .map { it.map { entity -> ChannelItem(entity.toChannelInfoItem(), entity.uid, ChannelItem.ItemVersion.MINI) } }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt
@@ -10,6 +10,8 @@ import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.processors.BehaviorProcessor
 import io.reactivex.rxjava3.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
+import org.schabi.newpipe.database.feed.model.FeedGroupEntity
+import org.schabi.newpipe.database.feed.model.FeedGroupEntity.Companion.GROUP_ALL_ID
 import org.schabi.newpipe.info_list.ItemViewMode
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
 import org.schabi.newpipe.local.subscription.item.ChannelItem
@@ -28,10 +30,14 @@ class SubscriptionViewModel(application: Application) : AndroidViewModel(applica
     )
     private val listViewModeFlowable = listViewMode.distinctUntilChanged()
 
+    private val selectedGroupId = BehaviorProcessor.createDefault(GROUP_ALL_ID)
+
     private val mutableStateLiveData = MutableLiveData<SubscriptionState>()
     private val mutableFeedGroupsLiveData = MutableLiveData<Pair<List<Group>, Boolean>>()
+    private val mutableSelectedGroupLiveData = MutableLiveData<Long>(GROUP_ALL_ID)
     val stateLiveData: LiveData<SubscriptionState> = mutableStateLiveData
     val feedGroupsLiveData: LiveData<Pair<List<Group>, Boolean>> = mutableFeedGroupsLiveData
+    val selectedGroupLiveData: LiveData<Long> = mutableSelectedGroupLiveData
 
     private var feedGroupItemsDisposable = Flowable
         .combineLatest(
@@ -52,10 +58,12 @@ class SubscriptionViewModel(application: Application) : AndroidViewModel(applica
             { mutableStateLiveData.postValue(SubscriptionState.ErrorState(it)) }
         )
 
-    private var stateItemsDisposable = subscriptionManager.subscriptions()
+    private var stateItemsDisposable = selectedGroupId
+        .switchMap { groupId ->
+            subscriptionManager.getSubscriptions(groupId).subscribeOn(Schedulers.io())
+        }
         .throttleLatest(DEFAULT_THROTTLE_TIMEOUT, TimeUnit.MILLISECONDS)
         .map { it.map { entity -> ChannelItem(entity.toChannelInfoItem(), entity.uid, ChannelItem.ItemVersion.MINI) } }
-        .subscribeOn(Schedulers.io())
         .subscribe(
             { mutableStateLiveData.postValue(SubscriptionState.LoadedState(it)) },
             { mutableStateLiveData.postValue(SubscriptionState.ErrorState(it)) }
@@ -74,6 +82,13 @@ class SubscriptionViewModel(application: Application) : AndroidViewModel(applica
     fun getListViewMode(): Boolean {
         return listViewMode.value ?: true
     }
+
+    fun selectGroup(groupId: Long) {
+        selectedGroupId.onNext(groupId)
+        mutableSelectedGroupLiveData.postValue(groupId)
+    }
+
+    fun getSelectedGroupId(): Long = selectedGroupId.value ?: GROUP_ALL_ID
 
     sealed class SubscriptionState {
         data class LoadedState(val subscriptions: List<Group>) : SubscriptionState()

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardGridItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardGridItem.kt
@@ -19,7 +19,7 @@ data class FeedGroupCardGridItem(
 
     override fun getId(): Long {
         return when (groupId) {
-            FeedGroupEntity.GROUP_ALL_ID -> super.getId()
+            FeedGroupEntity.GROUP_ALL_ID, FeedGroupEntity.GROUP_UNGROUPED_ID -> super.getId()
             else -> groupId
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardGridItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardGridItem.kt
@@ -1,16 +1,19 @@
 package org.schabi.newpipe.local.subscription.item
 
 import android.view.View
+import androidx.core.graphics.ColorUtils
 import com.xwray.groupie.viewbinding.BindableItem
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity
 import org.schabi.newpipe.databinding.FeedGroupCardGridItemBinding
 import org.schabi.newpipe.local.subscription.FeedGroupIcon
+import org.schabi.newpipe.util.ThemeHelper
 
 data class FeedGroupCardGridItem(
     val groupId: Long = FeedGroupEntity.GROUP_ALL_ID,
     val name: String,
-    val icon: FeedGroupIcon
+    val icon: FeedGroupIcon,
+    val isSelected: Boolean = false
 ) : BindableItem<FeedGroupCardGridItemBinding>() {
     constructor (feedGroupEntity: FeedGroupEntity) : this(feedGroupEntity.uid, feedGroupEntity.name, feedGroupEntity.icon)
 
@@ -26,6 +29,18 @@ data class FeedGroupCardGridItem(
     override fun bind(viewBinding: FeedGroupCardGridItemBinding, position: Int) {
         viewBinding.title.text = name
         viewBinding.icon.setImageResource(icon.getDrawableRes())
+        val context = viewBinding.root.context
+        viewBinding.root.setCardBackgroundColor(
+            if (isSelected) {
+                ColorUtils.blendARGB(
+                    ThemeHelper.resolveColorFromAttr(context, R.attr.card_item_background_color),
+                    ThemeHelper.resolveColorFromAttr(context, android.R.attr.colorAccent),
+                    0.15f
+                )
+            } else {
+                ThemeHelper.resolveColorFromAttr(context, R.attr.card_item_background_color)
+            }
+        )
     }
 
     override fun initializeViewBinding(view: View) = FeedGroupCardGridItemBinding.bind(view)

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardItem.kt
@@ -1,16 +1,19 @@
 package org.schabi.newpipe.local.subscription.item
 
 import android.view.View
+import androidx.core.graphics.ColorUtils
 import com.xwray.groupie.viewbinding.BindableItem
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity
 import org.schabi.newpipe.databinding.FeedGroupCardItemBinding
 import org.schabi.newpipe.local.subscription.FeedGroupIcon
+import org.schabi.newpipe.util.ThemeHelper
 
 data class FeedGroupCardItem(
     val groupId: Long = FeedGroupEntity.GROUP_ALL_ID,
     val name: String,
-    val icon: FeedGroupIcon
+    val icon: FeedGroupIcon,
+    val isSelected: Boolean = false
 ) : BindableItem<FeedGroupCardItemBinding>() {
     constructor (feedGroupEntity: FeedGroupEntity) : this(feedGroupEntity.uid, feedGroupEntity.name, feedGroupEntity.icon)
 
@@ -26,6 +29,18 @@ data class FeedGroupCardItem(
     override fun bind(viewBinding: FeedGroupCardItemBinding, position: Int) {
         viewBinding.title.text = name
         viewBinding.icon.setImageResource(icon.getDrawableRes())
+        val context = viewBinding.root.context
+        viewBinding.root.setCardBackgroundColor(
+            if (isSelected) {
+                ColorUtils.blendARGB(
+                    ThemeHelper.resolveColorFromAttr(context, R.attr.card_item_background_color),
+                    ThemeHelper.resolveColorFromAttr(context, android.R.attr.colorAccent),
+                    0.15f
+                )
+            } else {
+                ThemeHelper.resolveColorFromAttr(context, R.attr.card_item_background_color)
+            }
+        )
     }
 
     override fun initializeViewBinding(view: View) = FeedGroupCardItemBinding.bind(view)

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/FeedGroupCardItem.kt
@@ -19,7 +19,7 @@ data class FeedGroupCardItem(
 
     override fun getId(): Long {
         return when (groupId) {
-            FeedGroupEntity.GROUP_ALL_ID -> super.getId()
+            FeedGroupEntity.GROUP_ALL_ID, FeedGroupEntity.GROUP_UNGROUPED_ID -> super.getId()
             else -> groupId
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,6 +731,7 @@
     <string name="feed_group_dialog_delete_message">Do you want to delete this group?</string>
     <string name="feed_create_new_group_button_title">New</string>
     <string name="feed_group_show_only_ungrouped_subscriptions">Show only ungrouped subscriptions</string>
+    <string name="feed_group_ungrouped">Ungrouped</string>
     <string name="settings_category_feed_title">Feed</string>
     <string name="feed_update_threshold_title">Feed update threshold</string>
     <string name="feed_update_threshold_summary">Time after last update before a subscription is considered outdated — %s</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Tapping a channel group on the Subscriptions page now selects it and filters the channel list below to show only channels belonging to that group
- Tapping an already-selected group opens its recent videos feed (previous behaviour)
- "All" is selected by default, showing all subscriptions
- A new "Ungrouped" group is added at the end of the carousel, filtering the list to channels not assigned to any group

#### Before/After Screenshots/Screen Record
https://github.com/user-attachments/assets/fc543557-1ffb-4760-99c7-4f15bcedab55

#### Fixes the following issue(s)

#### Relies on the following changes

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [ ] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [ ] I tested the changes using an emulator or a physical device.
