### PR TITLE
[Refactor] Fix timestamp links in comments open external browser instead of seeking video

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
@@ -20,8 +20,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.TooltipCompat;
-import androidx.core.text.HtmlCompat;
-
 import com.google.android.material.chip.Chip;
 
 import org.schabi.newpipe.BaseFragment;
@@ -68,6 +66,17 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
      */
     @Nullable
     protected abstract Description getDescription();
+
+    /**
+     * Optional action to run after a timestamp in the description is clicked.
+     * Subclasses can override to e.g. scroll the UI to the player.
+     *
+     * @return runnable to execute, or null if no action needed
+     */
+    @Nullable
+    protected Runnable getAfterTimestampClickRunnable() {
+        return null;
+    }
 
     /**
      * Get the streaming service. Used for generating description links.
@@ -140,9 +149,9 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
         final Description description = getDescription();
         if (description != null) {
             TextLinkifier.fromDescription(binding.detailDescriptionView,
-                    description, HtmlCompat.FROM_HTML_MODE_LEGACY,
-                    getService(), getStreamUrl(),
-                    descriptionDisposables, SET_LINK_MOVEMENT_METHOD);
+                    description, getService(), getStreamUrl(),
+                    descriptionDisposables, SET_LINK_MOVEMENT_METHOD,
+                    getAfterTimestampClickRunnable());
         }
 
         binding.detailDescriptionNoteView.setVisibility(View.GONE);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -41,6 +41,18 @@ public class DescriptionFragment extends BaseDescriptionFragment {
         return streamInfo.getDescription();
     }
 
+    @Nullable
+    @Override
+    protected Runnable getAfterTimestampClickRunnable() {
+        return () -> {
+            final VideoDetailFragment parent =
+                    (VideoDetailFragment) getParentFragment();
+            if (parent != null) {
+                parent.scrollToTop();
+            }
+        };
+    }
+
     @NonNull
     @Override
     protected StreamingService getService() {

--- a/app/src/main/java/org/schabi/newpipe/ui/components/common/DescriptionText.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/components/common/DescriptionText.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -17,6 +18,7 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import org.schabi.newpipe.extractor.stream.Description
+import org.schabi.newpipe.util.external_communication.ShareUtils
 import org.schabi.newpipe.util.text.TimestampExtractor
 
 @Composable
@@ -46,6 +48,7 @@ fun rememberParsedDescription(
     // rememberUpdatedState lets the click handlers inside the AnnotatedString always invoke
     // the latest callback without rebuilding the string on every recomposition.
     val onTimestampClickState = rememberUpdatedState(onTimestampClick)
+    val contextState = rememberUpdatedState(LocalContext.current)
     // Use a boolean key so the string is only rebuilt when handler presence changes,
     // not on every lambda identity change.
     val hasTimestampHandler = onTimestampClick != null
@@ -57,41 +60,53 @@ fun rememberParsedDescription(
             val baseString = AnnotatedString.fromHtml(description.content, linkStyle)
             if (!hasTimestampHandler) return@remember baseString
 
-            // Rebuild the AnnotatedString, replacing YouTube timestamp URL annotations
-            // with Clickable ones so they seek the player instead of opening YouTube.
+            // Rebuild the AnnotatedString, replacing timestamp URL annotations
+            // with Clickable ones so they seek the player instead of opening the browser.
             buildAnnotatedString {
                 append(baseString.text)
-                for (span in baseString.spanStyles) {
+                baseString.spanStyles.forEach { span ->
                     addStyle(span.item, span.start, span.end)
                 }
-                for (para in baseString.paragraphStyles) {
+                baseString.paragraphStyles.forEach { para ->
                     addStyle(para.item, para.start, para.end)
                 }
 
                 val handledRanges = mutableListOf<IntRange>()
 
-                for (link in baseString.getLinkAnnotations(0, baseString.length)) {
+                baseString.getLinkAnnotations(0, baseString.length).forEach { link ->
                     val ann = link.item
-                    if (ann is LinkAnnotation.Url) {
-                        val secs = getTimestampSecondsFromUrl(ann.url)
-                        if (secs != null) {
-                            addLink(
-                                clickable = LinkAnnotation.Clickable(
-                                    tag = "timestamp",
-                                    styles = linkStyle,
-                                    linkInteractionListener = {
-                                        onTimestampClickState.value?.invoke(secs)
-                                    }
-                                ),
-                                start = link.start,
-                                end = link.end
-                            )
-                            handledRanges += link.start..link.end
-                            continue
+                    when (ann) {
+                        is LinkAnnotation.Url -> {
+                            val secs = getTimestampSecondsFromUrl(ann.url)
+                            if (secs != null) {
+                                addLink(
+                                    clickable = LinkAnnotation.Clickable(
+                                        tag = "timestamp",
+                                        styles = linkStyle,
+                                        linkInteractionListener = {
+                                            onTimestampClickState.value?.invoke(secs)
+                                        }
+                                    ),
+                                    start = link.start,
+                                    end = link.end
+                                )
+                                handledRanges += link.start..link.end
+                            } else {
+                                val url = ann.url
+                                addLink(
+                                    clickable = LinkAnnotation.Clickable(
+                                        tag = "url",
+                                        styles = ann.styles,
+                                        linkInteractionListener = {
+                                            ShareUtils.openUrlInApp(contextState.value, url)
+                                        }
+                                    ),
+                                    start = link.start,
+                                    end = link.end
+                                )
+                            }
                         }
-                        addLink(ann, link.start, link.end)
-                    } else if (ann is LinkAnnotation.Clickable) {
-                        addLink(ann, link.start, link.end)
+                        is LinkAnnotation.Clickable -> addLink(ann, link.start, link.end)
                     }
                 }
 
@@ -151,7 +166,7 @@ fun rememberParsedDescription(
 private fun getTimestampSecondsFromUrl(url: String): Int? {
     return try {
         Uri.parse(url).getQueryParameter("t")?.toIntOrNull()
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         null
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/ui/components/common/DescriptionText.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/components/common/DescriptionText.kt
@@ -106,6 +106,7 @@ fun rememberParsedDescription(
                                 )
                             }
                         }
+
                         is LinkAnnotation.Clickable -> addLink(ann, link.start, link.end)
                     }
                 }

--- a/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/Comment.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/Comment.kt
@@ -57,7 +57,7 @@ import org.schabi.newpipe.util.image.ImageStrategy
 @Composable
 fun Comment(
     comment: CommentsInfoItem,
-    onCommentAuthorOpened: () -> Unit,
+    onCommentAuthorOpened: () -> Unit = {},
     onTimestampClick: ((Int) -> Unit)? = null
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/org/schabi/newpipe/util/text/TextEllipsizer.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/TextEllipsizer.java
@@ -7,8 +7,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.text.HtmlCompat;
-
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.Description;
 
@@ -164,7 +162,7 @@ public final class TextEllipsizer {
         final boolean oldState = isEllipsized;
         disposable.clear();
         TextLinkifier.fromDescription(view, content,
-                HtmlCompat.FROM_HTML_MODE_LEGACY, streamingService, streamUrl, disposable,
+                streamingService, streamUrl, disposable,
                 v -> {
                     consumer.accept(v);
                     notifyStateChangeListener(oldState);

--- a/app/src/main/java/org/schabi/newpipe/util/text/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/TextLinkifier.java
@@ -48,8 +48,6 @@ public final class TextLinkifier {
      *
      * @param textView           the TextView to set the htmlBlock linked
      * @param description        the htmlBlock to be linked
-     * @param htmlCompatFlag     the int flag to be set if {@link HtmlCompat#fromHtml(String, int)}
-     *                           will be called (not used for formats different than HTML)
      * @param relatedInfoService if given, handle hashtags to search for the term in the correct
      *                           service
      * @param relatedStreamUrl   if given, used alongside {@code relatedInfoService} to handle
@@ -62,23 +60,59 @@ public final class TextLinkifier {
      */
     public static void fromDescription(@NonNull final TextView textView,
                                        @NonNull final Description description,
-                                       final int htmlCompatFlag,
                                        @Nullable final StreamingService relatedInfoService,
                                        @Nullable final String relatedStreamUrl,
                                        @NonNull final CompositeDisposable disposables,
                                        @Nullable final Consumer<TextView> onCompletion) {
+        fromDescription(textView, description, relatedInfoService,
+                relatedStreamUrl, disposables, onCompletion, null);
+    }
+
+    /**
+     * Like {@link #fromDescription(TextView, Description, StreamingService, String,
+     * CompositeDisposable, Consumer)} but with an extra callback that fires after a timestamp
+     * link is tapped and the player seek has been dispatched.
+     *
+     * @param textView              the TextView to set the linked description on
+     * @param description           the description to be linked
+     * @param relatedInfoService    if given, handle hashtags and timestamps for this service
+     * @param relatedStreamUrl      if given, used to open the stream in the popup player at the
+     *                              time indicated by a timestamp
+     * @param disposables           disposables created by the method are added here and their
+     *                              lifecycle should be handled by the calling class
+     * @param onCompletion          will be run when setting text to the textView completes; use
+     *                              {@link #SET_LINK_MOVEMENT_METHOD} to make links clickable
+     * @param onAfterTimestampClick invoked after a timestamp click is handled; use this to e.g.
+     *                              scroll the UI so the player is visible. May be {@code null}.
+     */
+    public static void fromDescription(@NonNull final TextView textView,
+                                       @NonNull final Description description,
+                                       @Nullable final StreamingService relatedInfoService,
+                                       @Nullable final String relatedStreamUrl,
+                                       @NonNull final CompositeDisposable disposables,
+                                       @Nullable final Consumer<TextView> onCompletion,
+                                       @Nullable final Runnable onAfterTimestampClick) {
         switch (description.getType()) {
             case Description.HTML:
-                TextLinkifier.fromHtml(textView, description.getContent(), htmlCompatFlag,
-                        relatedInfoService, relatedStreamUrl, disposables, onCompletion);
+                changeLinkIntents(textView,
+                        HtmlCompat.fromHtml(description.getContent(),
+                                HtmlCompat.FROM_HTML_MODE_LEGACY),
+                        relatedInfoService, relatedStreamUrl, disposables, onCompletion,
+                        onAfterTimestampClick);
                 break;
             case Description.MARKDOWN:
-                TextLinkifier.fromMarkdown(textView, description.getContent(),
-                        relatedInfoService, relatedStreamUrl, disposables, onCompletion);
+                changeLinkIntents(textView,
+                        Markwon.builder(textView.getContext())
+                                .usePlugin(LinkifyPlugin.create()).build()
+                                .toMarkdown(description.getContent()),
+                        relatedInfoService, relatedStreamUrl, disposables, onCompletion,
+                        onAfterTimestampClick);
                 break;
             case Description.PLAIN_TEXT: default:
-                TextLinkifier.fromPlainText(textView, description.getContent(),
-                        relatedInfoService, relatedStreamUrl, disposables, onCompletion);
+                textView.setAutoLinkMask(Linkify.WEB_URLS);
+                textView.setText(description.getContent(), TextView.BufferType.SPANNABLE);
+                changeLinkIntents(textView, textView.getText(), relatedInfoService,
+                        relatedStreamUrl, disposables, onCompletion, onAfterTimestampClick);
                 break;
         }
     }
@@ -115,7 +149,7 @@ public final class TextLinkifier {
                                 @Nullable final Consumer<TextView> onCompletion) {
         changeLinkIntents(
                 textView, HtmlCompat.fromHtml(htmlBlock, htmlCompatFlag), relatedInfoService,
-                relatedStreamUrl, disposables, onCompletion);
+                relatedStreamUrl, disposables, onCompletion, null);
     }
 
     /**
@@ -149,7 +183,7 @@ public final class TextLinkifier {
         textView.setAutoLinkMask(Linkify.WEB_URLS);
         textView.setText(plainTextBlock, TextView.BufferType.SPANNABLE);
         changeLinkIntents(textView, textView.getText(), relatedInfoService,
-                relatedStreamUrl, disposables, onCompletion);
+                relatedStreamUrl, disposables, onCompletion, null);
     }
 
     /**
@@ -182,7 +216,7 @@ public final class TextLinkifier {
         final Markwon markwon = Markwon.builder(textView.getContext())
                 .usePlugin(LinkifyPlugin.create()).build();
         changeLinkIntents(textView, markwon.toMarkdown(markdownBlock),
-                relatedInfoService, relatedStreamUrl, disposables, onCompletion);
+                relatedInfoService, relatedStreamUrl, disposables, onCompletion, null);
     }
 
     /**
@@ -221,13 +255,15 @@ public final class TextLinkifier {
      *                           lifecycle should be handled by the calling class
      * @param onCompletion       will be run when setting text to the textView completes; use {@link
      *                           #SET_LINK_MOVEMENT_METHOD} to make links clickable and focusable
+     * @param onAfterTimestampClick will be run after a timestamp link click action is resolved
      */
     private static void changeLinkIntents(@NonNull final TextView textView,
                                           @NonNull final CharSequence chars,
                                           @Nullable final StreamingService relatedInfoService,
                                           @Nullable final String relatedStreamUrl,
                                           @NonNull final CompositeDisposable disposables,
-                                          @Nullable final Consumer<TextView> onCompletion) {
+                                          @Nullable final Consumer<TextView> onCompletion,
+                                          @Nullable final Runnable onAfterTimestampClick) {
         disposables.add(Single.fromCallable(() -> {
                     final Context context = textView.getContext();
 
@@ -240,7 +276,8 @@ public final class TextLinkifier {
                     for (final URLSpan span : urls) {
                         final String url = span.getURL();
                         final LongPressClickableSpan longPressClickableSpan =
-                                new UrlLongPressClickableSpan(context, url);
+                                new UrlLongPressClickableSpan(context, url,
+                                        onAfterTimestampClick);
 
                         textBlockLinked.setSpan(longPressClickableSpan,
                                 textBlockLinked.getSpanStart(span),
@@ -254,7 +291,8 @@ public final class TextLinkifier {
                     if (relatedInfoService != null) {
                         if (relatedStreamUrl != null) {
                             addClickListenersOnTimestamps(context, textBlockLinked,
-                                    relatedInfoService, relatedStreamUrl, disposables);
+                                    relatedInfoService, relatedStreamUrl, disposables,
+                                    onAfterTimestampClick);
                         }
                         addClickListenersOnHashtags(context, textBlockLinked, relatedInfoService);
                     }
@@ -329,13 +367,15 @@ public final class TextLinkifier {
      * @param relatedStreamUrl     what to open in the popup player when timestamps are clicked
      * @param disposables          disposables created by the method are added here and their
      *                             lifecycle should be handled by the calling class
+     * @param onAfterTimestampClick will be run after a timestamp link click action is resolved
      */
     private static void addClickListenersOnTimestamps(
             @NonNull final Context context,
             @NonNull final SpannableStringBuilder spannableDescription,
             @NonNull final StreamingService relatedInfoService,
             @NonNull final String relatedStreamUrl,
-            @NonNull final CompositeDisposable disposables) {
+            @NonNull final CompositeDisposable disposables,
+            @Nullable final Runnable onAfterTimestampClick) {
         final String descriptionText = spannableDescription.toString();
         final Matcher timestampsMatches = TimestampExtractor.TIMESTAMPS_PATTERN.matcher(
                 descriptionText);
@@ -350,7 +390,8 @@ public final class TextLinkifier {
 
             spannableDescription.setSpan(
                     new TimestampLongPressClickableSpan(context, descriptionText, disposables,
-                            relatedInfoService, relatedStreamUrl, timestampMatchDTO),
+                            relatedInfoService, relatedStreamUrl, timestampMatchDTO,
+                            onAfterTimestampClick),
                     timestampMatchDTO.timestampStart(),
                     timestampMatchDTO.timestampEnd(),
                     0);

--- a/app/src/main/java/org/schabi/newpipe/util/text/TimestampLongPressClickableSpan.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/text/TimestampLongPressClickableSpan.kt
@@ -13,13 +13,21 @@ import org.schabi.newpipe.extractor.StreamingService
 import org.schabi.newpipe.util.external_communication.ShareUtils
 import org.schabi.newpipe.util.text.TimestampExtractor.TimestampMatchDTO
 
+/**
+ * A [LongPressClickableSpan] that seeks the player to a timestamp on click and copies the
+ * timestamp URL to the clipboard on long-click.
+ *
+ * @param onAfterClick optional callback invoked after the seek intent is dispatched, e.g. to
+ *   scroll the UI back to the player so the user can see the updated position.
+ */
 class TimestampLongPressClickableSpan(
     private val context: Context,
     private val descriptionText: String,
     private val disposables: CompositeDisposable,
     private val relatedInfoService: StreamingService,
     private val relatedStreamUrl: String,
-    private val timestampMatchDTO: TimestampMatchDTO
+    private val timestampMatchDTO: TimestampMatchDTO,
+    private val onAfterClick: Runnable? = null
 ) : LongPressClickableSpan() {
     override fun onClick(view: View) {
         InternalUrlsHandler.playOnPopup(
@@ -28,6 +36,7 @@ class TimestampLongPressClickableSpan(
             relatedInfoService,
             timestampMatchDTO.seconds()
         )
+        onAfterClick?.run()
     }
 
     override fun onLongClick(view: View) {

--- a/app/src/main/java/org/schabi/newpipe/util/text/UrlLongPressClickableSpan.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/UrlLongPressClickableSpan.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
@@ -13,16 +14,27 @@ final class UrlLongPressClickableSpan extends LongPressClickableSpan {
     private final Context context;
     @NonNull
     private final String url;
+    @Nullable
+    private final Runnable onAfterTimestampClick;
 
     UrlLongPressClickableSpan(@NonNull final Context context,
-                              @NonNull final String url) {
+                              @NonNull final String url,
+                              @Nullable final Runnable onAfterTimestampClick) {
         this.context = context;
         this.url = url;
+        this.onAfterTimestampClick = onAfterTimestampClick;
     }
 
     @Override
     public void onClick(@NonNull final View view) {
-        if (!InternalUrlsHandler.handleUrlDescriptionTimestamp(context, url)) {
+        // handleUrlDescriptionTimestamp returns true when the URL is a timestamp link and the
+        // player seek was dispatched; only then scroll back to the player. Regular URLs fall
+        // through to the browser/app chooser and should not trigger a scroll.
+        if (InternalUrlsHandler.handleUrlDescriptionTimestamp(context, url)) {
+            if (onAfterTimestampClick != null) {
+                onAfterTimestampClick.run();
+            }
+        } else {
             ShareUtils.openUrlInApp(context, url);
         }
     }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Add timestamp click handling to `DescriptionText` in Compose.
- Detect timestamp patterns in comment text and convert them into clickable timestamp links.
- Pass an `onTimestampClick` callback from the comments UI down to the text component.
- Make timestamp clicks in comments seek the currently opened video instead of opening an external browser or app.
- Keep normal non-timestamp links handled as regular links.
- Reuse the existing timestamp parsing logic instead of introducing a separate parser.
- Scroll to player when tapping a timestamp in the description. When a timestamp link in the video description is tapped, expand the
AppBar to reveal the player in addition to seeking. This mirrors the
existing behaviour in the comments tab

#### Fixes the following issue(s)

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [ ] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [ ] I tested the changes using an emulator or a physical device.
