### PR TITLE
Add voice "play from search" support (Android Auto / Assistant)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -429,6 +429,25 @@
             </intent-filter>
 
         </activity>
+
+        <!-- Declares voice "play from search" support. Android Auto / Assistant only route a
+             spoken MEDIA_PLAY_FROM_SEARCH command to the MediaSession (onPlayFromSearch) when the
+             app declares an activity with this *bare* intent filter (no data constraints) - see
+             android/uamp#479. This activity also directly handles the legacy activity-style
+             MEDIA_PLAY_FROM_SEARCH intent (e.g. from automation tools) by searching and playing. -->
+        <activity
+            android:name=".PlayMediaFromSearchActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".RouterActivity$FetcherService"
             android:foregroundServiceType="dataSync"

--- a/app/src/main/java/org/schabi/newpipe/PlayMediaFromSearchActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/PlayMediaFromSearchActivity.kt
@@ -1,0 +1,87 @@
+package org.schabi.newpipe
+
+import android.app.Activity
+import android.app.SearchManager
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.player.playqueue.SinglePlayQueue
+import org.schabi.newpipe.util.ExtractorHelper
+import org.schabi.newpipe.util.NavigationHelper
+import org.schabi.newpipe.util.ServiceHelper
+
+/**
+ * Handles the "Play <something>" voice intent ([android.media.action.MEDIA_PLAY_FROM_SEARCH]) when
+ * it arrives as a plain text query (i.e. without a media URL), e.g. from Google Assistant or an
+ * automation tool.
+ *
+ * Declaring this activity with a bare MEDIA_PLAY_FROM_SEARCH intent filter is also what makes
+ * Android Auto route spoken play-from-search commands to our MediaSession (see
+ * MediaBrowserPlaybackPreparer.onPrepareFromSearch); Auto uses the session path and does not
+ * actually launch this activity.
+ *
+ * When launched directly, it searches the user's selected service and starts background playback of
+ * the first matching stream, falling back to the search results screen if nothing is found.
+ *
+ * It has no UI of its own (translucent theme): it kicks off playback and finishes.
+ */
+class PlayMediaFromSearchActivity : Activity() {
+    private var searchDisposable: Disposable? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val query = intent?.getStringExtra(SearchManager.QUERY)
+            ?: intent?.getStringExtra(Intent.EXTRA_TEXT)
+
+        if (query.isNullOrBlank()) {
+            // Nothing to search for; just open the app rather than failing silently.
+            NavigationHelper.openMainActivity(this)
+            finish()
+            return
+        }
+
+        val serviceId = ServiceHelper.getSelectedServiceId(this)
+
+        searchDisposable = ExtractorHelper.searchFor(serviceId, query, emptyList(), "")
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { searchInfo ->
+                    val firstStream = searchInfo.relatedItems
+                        .filterIsInstance<StreamInfoItem>()
+                        .firstOrNull()
+                    if (firstStream == null) {
+                        // No playable result: show the search results screen as a fallback.
+                        NavigationHelper.openSearch(this, serviceId, query)
+                    } else {
+                        NavigationHelper.playOnBackgroundPlayer(
+                            this,
+                            SinglePlayQueue(firstStream),
+                            true
+                        )
+                    }
+                    finish()
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to play from search query [$query]", throwable)
+                    // Don't dead-end the user: fall back to the search results screen.
+                    NavigationHelper.openSearch(this, serviceId, query)
+                    finish()
+                }
+            )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        searchDisposable?.dispose()
+    }
+
+    companion object {
+        private val TAG = PlayMediaFromSearchActivity::class.java.simpleName
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
@@ -23,6 +23,7 @@ import org.schabi.newpipe.error.ErrorInfo
 import org.schabi.newpipe.extractor.InfoItem.InfoType
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.playlist.LocalPlaylistManager
 import org.schabi.newpipe.local.playlist.RemotePlaylistManager
 import org.schabi.newpipe.player.playqueue.ChannelTabPlayQueue
@@ -32,6 +33,7 @@ import org.schabi.newpipe.player.playqueue.SinglePlayQueue
 import org.schabi.newpipe.util.ChannelTabHelper
 import org.schabi.newpipe.util.ExtractorHelper
 import org.schabi.newpipe.util.NavigationHelper
+import org.schabi.newpipe.util.ServiceHelper
 
 /**
  * This class is used to cleanly separate the Service implementation (in
@@ -62,7 +64,13 @@ class MediaBrowserPlaybackPreparer(
 
     //region Overrides
     override fun getSupportedPrepareActions(): Long {
-        return PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID
+        // Advertise both PLAY_FROM and PREPARE_FROM variants (UAMP pattern): some controllers send
+        // prepareFromSearch instead of playFromSearch, and the connector drops it unless the
+        // matching action is advertised.
+        return PlaybackStateCompat.ACTION_PREPARE_FROM_MEDIA_ID or
+            PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID or
+            PlaybackStateCompat.ACTION_PREPARE_FROM_SEARCH or
+            PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH
     }
 
     override fun onPrepare(playWhenReady: Boolean) {
@@ -91,7 +99,50 @@ class MediaBrowserPlaybackPreparer(
     }
 
     override fun onPrepareFromSearch(query: String, playWhenReady: Boolean, extras: Bundle?) {
-        onUnsupportedError()
+        if (MainActivity.DEBUG) {
+            Log.d(TAG, "onPrepareFromSearch($query, $playWhenReady, $extras)")
+        }
+
+        // An empty query (e.g. a bare "play music" voice command, which Android Auto / AAOS can
+        // send) should start something rather than error out: returning ERROR_CODE_NOT_SUPPORTED
+        // can make the voice agent treat the app as not search-capable. Resume the most recently
+        // played stream instead.
+        if (query.isBlank()) {
+            playMostRecentlyPlayed(playWhenReady)
+            return
+        }
+
+        // Search the user's currently selected service (YouTube by default) and play the first
+        // stream result, mirroring the "Play <something> on NewPipe" voice intent.
+        val serviceId = ServiceHelper.getSelectedServiceId(context)
+
+        disposable?.dispose()
+        disposable = ExtractorHelper.searchFor(serviceId, query, emptyList(), "")
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { searchInfo ->
+                    val firstStream = searchInfo.relatedItems
+                        .filterIsInstance<StreamInfoItem>()
+                        .firstOrNull()
+                    if (firstStream == null) {
+                        onPrepareError(
+                            ContentNotAvailableException("No streams found for query \"$query\"")
+                        )
+                    } else {
+                        clearMediaSessionError.run()
+                        NavigationHelper.playOnBackgroundPlayer(
+                            context,
+                            SinglePlayQueue(firstStream),
+                            playWhenReady
+                        )
+                    }
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to play from search query [$query]", throwable)
+                    onPrepareError(throwable)
+                }
+            )
     }
 
     override fun onPrepareFromUri(uri: Uri, playWhenReady: Boolean, extras: Bundle?) {
@@ -125,6 +176,33 @@ class MediaBrowserPlaybackPreparer(
     //endregion
 
     //region Building play queues from playlists and history
+    private fun playMostRecentlyPlayed(playWhenReady: Boolean) {
+        disposable?.dispose()
+        disposable = database.streamHistoryDAO().history
+            .firstOrError()
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { history ->
+                    val mostRecent = history.firstOrNull()?.toStreamInfoItem()
+                    if (mostRecent == null) {
+                        onUnsupportedError()
+                    } else {
+                        clearMediaSessionError.run()
+                        NavigationHelper.playOnBackgroundPlayer(
+                            context,
+                            SinglePlayQueue(mostRecent),
+                            playWhenReady
+                        )
+                    }
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to play most recent stream for empty query", throwable)
+                    onPrepareError(throwable)
+                }
+            )
+    }
+
     private fun extractLocalPlayQueue(playlistId: Long, index: Int): Single<PlayQueue> {
         return LocalPlaylistManager(database).getPlaylistStreams(playlistId).firstOrError()
             .map { items -> SinglePlayQueue(items.map { it.toStreamInfoItem() }, index) }


### PR DESCRIPTION
What this PR Adds
As the title suggests, you can now say "Play x" on Android Auto and it'll play x on NewPipe - with slight caveats (see below)
https://github.com/user-attachments/assets/88fb16d8-0555-47e6-8654-845397a9f02c


#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)

#### Description of the changes in your PR
Implement MediaBrowserPlaybackPreparer.onPrepareFromSearch (previously a no-op that returned ERROR_CODE_NOT_SUPPORTED): search the user's selected service and start background playback of the first matching stream. An empty query (e.g. a bare "play music" voice command) resumes the most recently played stream instead of erroring, so voice agents don't treat the app as non-search-capable.

Advertise the PREPARE/PLAY variants for both media id and search in getSupportedPrepareActions(), so the MediaSessionConnector delegates prepareFromSearch as well as playFromSearch.

Add PlayMediaFromSearchActivity with a bare MEDIA_PLAY_FROM_SEARCH intent filter (no data constraints). Android Auto only routes a spoken play-from-search to an app's MediaSession when such an activity is declared (see android/uamp#479); the existing filters on RouterActivity are all gated behind YouTube-URL data constraints and don't qualify. The activity also handles the activity-style intent directly (search + play) as a fallback.

#### Relies on the following changes

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [ ] I tested the changes using an emulator or a physical device.
