### PR TITLE
feat(player): add volume boost with automatic real-time gain

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -30,9 +30,12 @@ import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
 import static com.google.android.exoplayer2.Player.RepeatMode;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveAutoVolumeBoostFromPrefs;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrievePlaybackParametersFromPrefs;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
+import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveVolumeBoostFromPrefs;
 import static org.schabi.newpipe.player.helper.PlayerHelper.savePlaybackParametersToPrefs;
+import static org.schabi.newpipe.player.helper.PlayerHelper.saveVolumeBoostToPrefs;
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD;
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND;
@@ -67,7 +70,6 @@ import androidx.core.math.MathUtils;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
@@ -102,6 +104,7 @@ import org.schabi.newpipe.player.helper.CustomRenderersFactory;
 import org.schabi.newpipe.player.helper.LoadController;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.helper.VolumeBoostRenderersFactory;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.mediasession.MediaSessionPlayerUi;
 import org.schabi.newpipe.player.notification.NotificationPlayerUi;
@@ -214,7 +217,7 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final LoadController loadController;
     @NonNull
-    private final DefaultRenderersFactory renderFactory;
+    private final VolumeBoostRenderersFactory renderFactory;
 
     @NonNull
     private final VideoPlaybackResolver videoResolver;
@@ -299,7 +302,8 @@ public final class Player implements PlaybackListener, Listener {
         renderFactory = prefs.getBoolean(
                 context.getString(
                         R.string.always_use_exoplayer_set_output_surface_workaround_key), false)
-                ? new CustomRenderersFactory(context) : new DefaultRenderersFactory(context);
+                ? new CustomRenderersFactory(context)
+                : new VolumeBoostRenderersFactory(context);
 
         renderFactory.setEnableDecoderFallback(
                 prefs.getBoolean(
@@ -607,6 +611,8 @@ public final class Player implements PlaybackListener, Listener {
                 R.string.playback_skip_silence_key), getPlaybackSkipSilence());
         final PlaybackParameters savedParameters = retrievePlaybackParametersFromPrefs(this);
         setPlaybackParameters(savedParameters.speed, savedParameters.pitch, playbackSkipSilence);
+        setVolumeBoost(retrieveVolumeBoostFromPrefs(this),
+                retrieveAutoVolumeBoostFromPrefs(this));
 
         playQueue = queue;
         playQueue.init();
@@ -964,6 +970,32 @@ public final class Player implements PlaybackListener, Listener {
 
     public boolean getPlaybackSkipSilence() {
         return !exoPlayerIsNull() && simpleExoPlayer.getSkipSilenceEnabled();
+    }
+
+    public float getVolumeBoost() {
+        return renderFactory.getVolumeBoost();
+    }
+
+    public boolean isAutoVolumeBoostEnabled() {
+        return renderFactory.isAutomaticVolumeBoost();
+    }
+
+    /**
+     * Sets how much the decoded audio should be amplified, and also saves it to shared
+     * preferences. The gain is rounded up to 2 decimal places before being used or saved.
+     *
+     * @param volumeBoost     the gain to apply when {@code autoVolumeBoost} is disabled, where 1
+     *                        means no amplification at all
+     * @param autoVolumeBoost whether the gain should instead be computed in real time from the
+     *                        loudness of the stream being played
+     */
+    public void setVolumeBoost(final float volumeBoost, final boolean autoVolumeBoost) {
+        final float roundedVolumeBoost = Math.round(volumeBoost * 100.0f) / 100.0f;
+
+        saveVolumeBoostToPrefs(this, roundedVolumeBoost, autoVolumeBoost);
+        renderFactory.setVolumeBoost(roundedVolumeBoost);
+        renderFactory.setAutomaticVolumeBoost(autoVolumeBoost);
+        UIs.call(PlayerUi::onVolumeBoostChanged);
     }
 
     public PlaybackParameters getPlaybackParameters() {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.player.helper;
 import android.content.Context;
 import android.os.Handler;
 
-import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.Renderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
@@ -11,8 +10,8 @@ import com.google.android.exoplayer2.video.VideoRendererEventListener;
 import java.util.ArrayList;
 
 /**
- * A {@link DefaultRenderersFactory} which only uses {@link CustomMediaCodecVideoRenderer} as an
- * implementation of video codec renders.
+ * A {@link VolumeBoostRenderersFactory} which only uses {@link CustomMediaCodecVideoRenderer} as
+ * an implementation of video codec renders.
  *
  * <p>
  * As no ExoPlayer extension is currently used, the reflection code used by ExoPlayer to try to
@@ -20,7 +19,7 @@ import java.util.ArrayList;
  * changed in the case an extension is shipped with the app, such as the AV1 one.
  * </p>
  */
-public final class CustomRenderersFactory extends DefaultRenderersFactory {
+public final class CustomRenderersFactory extends VolumeBoostRenderersFactory {
 
     public CustomRenderersFactory(final Context context) {
         super(context);

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -454,6 +454,27 @@ public final class PlayerHelper {
                 .apply();
     }
 
+    public static float retrieveVolumeBoostFromPrefs(final Player player) {
+        return player.getPrefs().getFloat(player.getContext().getString(
+                R.string.playback_volume_boost_key), player.getVolumeBoost());
+    }
+
+    public static boolean retrieveAutoVolumeBoostFromPrefs(final Player player) {
+        return player.getPrefs().getBoolean(player.getContext().getString(
+                R.string.playback_auto_volume_boost_key), player.isAutoVolumeBoostEnabled());
+    }
+
+    public static void saveVolumeBoostToPrefs(final Player player,
+                                              final float volumeBoost,
+                                              final boolean autoVolumeBoost) {
+        player.getPrefs().edit()
+                .putFloat(player.getContext().getString(R.string.playback_volume_boost_key),
+                        volumeBoost)
+                .putBoolean(player.getContext().getString(R.string.playback_auto_volume_boost_key),
+                        autoVolumeBoost)
+                .apply();
+    }
+
     public static float getMinimumVideoHeight(final float width) {
         return width / (16.0f / 9.0f); // Respect the 16:9 ratio that most videos have
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/VolumeBoostAudioProcessor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/VolumeBoostAudioProcessor.java
@@ -1,0 +1,261 @@
+package org.schabi.newpipe.player.helper;
+
+import androidx.core.math.MathUtils;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.audio.BaseAudioProcessor;
+
+import java.nio.ByteBuffer;
+
+/**
+ * An {@link com.google.android.exoplayer2.audio.AudioProcessor} which amplifies the decoded PCM
+ * samples by a gain factor, allowing playback to become louder than the maximum volume the system
+ * would normally allow.
+ *
+ * <p>
+ * Samples exceeding the range representable by the current encoding are clipped, which is why
+ * boosting too much introduces distortion. This is the same trade-off other players (e.g. VLC)
+ * make for their volume boost feature.
+ * </p>
+ *
+ * <p>
+ * The gain is either chosen by the user, or, when the automatic mode is enabled, continuously
+ * computed from the loudness of the stream itself: quiet passages are amplified up to
+ * {@link #MAXIMUM_VOLUME_BOOST} while already loud ones are left untouched. The automatic gain
+ * follows the signal with a fast attack and a slow release, so that a sudden loud passage is
+ * brought back down almost immediately (avoiding clipping) while the amplification of a quiet
+ * passage ramps up smoothly instead of pumping.
+ * </p>
+ *
+ * <p>
+ * The processor is always active, even when the gain is {@link #MINIMUM_VOLUME_BOOST}, so that the
+ * gain can be changed while playing without having to reconfigure the audio sink.
+ * </p>
+ */
+public final class VolumeBoostAudioProcessor extends BaseAudioProcessor {
+
+    /**
+     * No amplification at all, i.e. the original volume of the stream.
+     */
+    public static final float MINIMUM_VOLUME_BOOST = 1.00f;
+
+    /**
+     * The loudest amplification allowed, i.e. three times the original volume.
+     */
+    public static final float MAXIMUM_VOLUME_BOOST = 3.00f;
+
+    private static final int PCM_16_BIT_SAMPLE_SIZE = 2;
+    private static final int PCM_FLOAT_SAMPLE_SIZE = 4;
+
+    /**
+     * The loudness the automatic mode tries to reach, as a root mean square of samples normalized
+     * to {@code [-1, 1]}. This is roughly -16 dBFS, which is about as loud as a well mastered
+     * stream, and is only ever reached by amplifying, never by attenuating.
+     */
+    private static final float AUTOMATIC_TARGET_LOUDNESS = 0.15f;
+
+    /**
+     * The automatic gain is reduced so that the loudest sample of the buffer being processed stays
+     * below this value, leaving a bit of headroom to limit clipping.
+     */
+    private static final float AUTOMATIC_PEAK_CEILING = 0.98f;
+
+    /**
+     * Buffers quieter than this are considered silence, and leave the automatic gain untouched
+     * instead of making it jump to the maximum.
+     */
+    private static final float AUTOMATIC_SILENCE_LOUDNESS = 0.001f;
+
+    /**
+     * How long the automatic gain takes to (mostly) reach a lower gain, in seconds.
+     */
+    private static final float AUTOMATIC_ATTACK_SECONDS = 0.05f;
+
+    /**
+     * How long the automatic gain takes to (mostly) reach a higher gain, in seconds.
+     */
+    private static final float AUTOMATIC_RELEASE_SECONDS = 2.0f;
+
+    /**
+     * Read from the audio processing thread, written from the main thread.
+     */
+    private volatile float volumeBoost = MINIMUM_VOLUME_BOOST;
+
+    /**
+     * Read from the audio processing thread, written from the main thread.
+     */
+    private volatile boolean automaticVolumeBoost = false;
+
+    /**
+     * The gain currently applied by the automatic mode. Only touched by the audio processing
+     * thread, except when it is reset while the processor is flushed.
+     */
+    private float automaticGain = MINIMUM_VOLUME_BOOST;
+
+    private float attackCoefficient = 1.0f;
+    private float releaseCoefficient = 1.0f;
+
+    public float getVolumeBoost() {
+        return volumeBoost;
+    }
+
+    public void setVolumeBoost(final float newVolumeBoost) {
+        volumeBoost = MathUtils.clamp(newVolumeBoost, MINIMUM_VOLUME_BOOST, MAXIMUM_VOLUME_BOOST);
+    }
+
+    public boolean isAutomaticVolumeBoost() {
+        return automaticVolumeBoost;
+    }
+
+    public void setAutomaticVolumeBoost(final boolean newAutomaticVolumeBoost) {
+        automaticVolumeBoost = newAutomaticVolumeBoost;
+    }
+
+    @Override
+    protected AudioFormat onConfigure(final AudioFormat inputAudioFormat)
+            throws UnhandledAudioFormatException {
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT
+                && inputAudioFormat.encoding != C.ENCODING_PCM_FLOAT) {
+            // let the sink know that other encodings (e.g. passthrough) can't be amplified
+            throw new UnhandledAudioFormatException(inputAudioFormat);
+        }
+
+        // the gain is smoothed once per sample, so the time constants depend on how many samples
+        // (not frames) of this format make up a second
+        final float samplesPerSecond =
+                (float) inputAudioFormat.sampleRate * inputAudioFormat.channelCount;
+        attackCoefficient = smoothingCoefficient(AUTOMATIC_ATTACK_SECONDS, samplesPerSecond);
+        releaseCoefficient = smoothingCoefficient(AUTOMATIC_RELEASE_SECONDS, samplesPerSecond);
+
+        return inputAudioFormat;
+    }
+
+    @Override
+    protected void onFlush() {
+        // the next buffer may come from a completely different position or stream, so start over
+        automaticGain = MINIMUM_VOLUME_BOOST;
+    }
+
+    @Override
+    public void queueInput(final ByteBuffer inputBuffer) {
+        final int limit = inputBuffer.limit();
+        final int position = inputBuffer.position();
+
+        if (position == limit) {
+            // The audio pipeline hands over the shared empty buffer when there is nothing to
+            // process, and that is the very same buffer replaceOutputBuffer() returns for an empty
+            // output, so going any further would make that buffer be copied onto itself.
+            replaceOutputBuffer(0).flip();
+            return;
+        }
+
+        final ByteBuffer buffer = replaceOutputBuffer(limit - position);
+        final boolean automatic = automaticVolumeBoost;
+        final float gain = volumeBoost;
+        final boolean pcm16Bit = inputAudioFormat.encoding == C.ENCODING_PCM_16BIT;
+
+        if (!automatic && gain == MINIMUM_VOLUME_BOOST) {
+            buffer.put(inputBuffer);
+            buffer.flip();
+            return;
+        }
+
+        if (automatic) {
+            amplifyAutomatically(inputBuffer, buffer, position, limit, pcm16Bit);
+        } else if (pcm16Bit) {
+            for (int i = position; i < limit; i += PCM_16_BIT_SAMPLE_SIZE) {
+                buffer.putShort(amplify(inputBuffer.getShort(i), gain));
+            }
+        } else {
+            for (int i = position; i < limit; i += PCM_FLOAT_SAMPLE_SIZE) {
+                buffer.putFloat(amplify(inputBuffer.getFloat(i), gain));
+            }
+        }
+
+        inputBuffer.position(limit);
+        buffer.flip();
+    }
+
+    private void amplifyAutomatically(final ByteBuffer inputBuffer,
+                                      final ByteBuffer outputBuffer,
+                                      final int position,
+                                      final int limit,
+                                      final boolean pcm16Bit) {
+        final int sampleSize = pcm16Bit ? PCM_16_BIT_SAMPLE_SIZE : PCM_FLOAT_SAMPLE_SIZE;
+        final float targetGain = calculateAutomaticGain(inputBuffer, position, limit, pcm16Bit);
+        // reaching a lower gain quickly keeps a sudden loud passage from being clipped, while
+        // reaching a higher gain slowly keeps the amplification from audibly pumping
+        final float coefficient =
+                targetGain < automaticGain ? attackCoefficient : releaseCoefficient;
+
+        for (int i = position; i < limit; i += sampleSize) {
+            automaticGain += (targetGain - automaticGain) * coefficient;
+            if (pcm16Bit) {
+                outputBuffer.putShort(amplify(inputBuffer.getShort(i), automaticGain));
+            } else {
+                outputBuffer.putFloat(amplify(inputBuffer.getFloat(i), automaticGain));
+            }
+        }
+    }
+
+    /**
+     * Computes the gain that would bring the provided buffer to {@link #AUTOMATIC_TARGET_LOUDNESS}
+     * without pushing its loudest sample past {@link #AUTOMATIC_PEAK_CEILING}.
+     *
+     * @param inputBuffer the buffer about to be processed
+     * @param position    the index of the first byte to take into account
+     * @param limit       the index after the last byte to take into account
+     * @param pcm16Bit    whether the buffer holds 16 bit samples instead of float ones
+     * @return the gain to converge to, always within the allowed volume boost range
+     */
+    private float calculateAutomaticGain(final ByteBuffer inputBuffer,
+                                         final int position,
+                                         final int limit,
+                                         final boolean pcm16Bit) {
+        final int sampleSize = pcm16Bit ? PCM_16_BIT_SAMPLE_SIZE : PCM_FLOAT_SAMPLE_SIZE;
+        double sumOfSquares = 0.0;
+        float peak = 0.0f;
+        int sampleCount = 0;
+
+        for (int i = position; i < limit; i += sampleSize) {
+            final float sample = pcm16Bit
+                    ? inputBuffer.getShort(i) / (float) -Short.MIN_VALUE
+                    : inputBuffer.getFloat(i);
+            sumOfSquares += (double) sample * sample;
+            peak = Math.max(peak, Math.abs(sample));
+            sampleCount++;
+        }
+
+        final float loudness = sampleCount == 0
+                ? 0.0f : (float) Math.sqrt(sumOfSquares / sampleCount);
+        if (loudness < AUTOMATIC_SILENCE_LOUDNESS) {
+            // there is nothing to measure, so keep whatever gain is currently being applied
+            return automaticGain;
+        }
+
+        float gain = AUTOMATIC_TARGET_LOUDNESS / loudness;
+        if (peak > 0.0f) {
+            gain = Math.min(gain, AUTOMATIC_PEAK_CEILING / peak);
+        }
+        return MathUtils.clamp(gain, MINIMUM_VOLUME_BOOST, MAXIMUM_VOLUME_BOOST);
+    }
+
+    /**
+     * @param seconds          the time the smoothed value takes to cover about 63% of the distance
+     *                         to the value it converges to
+     * @param samplesPerSecond how many samples are smoothed every second
+     * @return the factor of the remaining distance to cover with every single sample
+     */
+    private static float smoothingCoefficient(final float seconds, final float samplesPerSecond) {
+        return (float) (1.0 - Math.exp(-1.0 / (seconds * samplesPerSecond)));
+    }
+
+    private static short amplify(final short sample, final float gain) {
+        return (short) MathUtils.clamp(Math.round(sample * gain),
+                Short.MIN_VALUE, Short.MAX_VALUE);
+    }
+
+    private static float amplify(final float sample, final float gain) {
+        return MathUtils.clamp(sample * gain, -1.0f, 1.0f);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/helper/VolumeBoostDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/VolumeBoostDialog.java
@@ -1,0 +1,185 @@
+package org.schabi.newpipe.player.helper;
+
+import static org.schabi.newpipe.player.helper.VolumeBoostAudioProcessor.MAXIMUM_VOLUME_BOOST;
+import static org.schabi.newpipe.player.helper.VolumeBoostAudioProcessor.MINIMUM_VOLUME_BOOST;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.SeekBar;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.math.MathUtils;
+import androidx.fragment.app.DialogFragment;
+
+import com.evernote.android.state.State;
+import com.livefront.bridge.Bridge;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.databinding.DialogVolumeBoostBinding;
+import org.schabi.newpipe.util.SimpleOnSeekBarChangeListener;
+import org.schabi.newpipe.util.SliderStrategy;
+
+/**
+ * Dialog letting the user amplify the audio of the stream being played, either by picking a gain
+ * themselves or by letting the player adjust it in real time based on how loud the stream is.
+ */
+public class VolumeBoostDialog extends DialogFragment {
+
+    private static final double MIN_VOLUME_BOOST = MINIMUM_VOLUME_BOOST;
+    private static final double MAX_VOLUME_BOOST = MAXIMUM_VOLUME_BOOST;
+    private static final double VOLUME_BOOST_STEP = 0.25f;
+
+    private static final SliderStrategy STRATEGY = new SliderStrategy.Linear(
+            MIN_VOLUME_BOOST,
+            MAX_VOLUME_BOOST,
+            10_000);
+
+    @Nullable
+    private Callback callback;
+
+    @State
+    double initialVolumeBoost = MIN_VOLUME_BOOST;
+    @State
+    boolean initialAutoVolumeBoost = false;
+
+    @State
+    double volumeBoost = MIN_VOLUME_BOOST;
+    @State
+    boolean autoVolumeBoost = false;
+
+    private DialogVolumeBoostBinding binding;
+
+    public static VolumeBoostDialog newInstance(final double playbackVolumeBoost,
+                                                final boolean playbackAutoVolumeBoost,
+                                                final Callback callback) {
+        final VolumeBoostDialog dialog = new VolumeBoostDialog();
+        dialog.callback = callback;
+
+        dialog.initialVolumeBoost = playbackVolumeBoost;
+        dialog.initialAutoVolumeBoost = playbackAutoVolumeBoost;
+
+        dialog.volumeBoost = dialog.initialVolumeBoost;
+        dialog.autoVolumeBoost = dialog.initialAutoVolumeBoost;
+
+        return dialog;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        Bridge.saveInstanceState(this, outState);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
+        Bridge.restoreInstanceState(this, savedInstanceState);
+
+        binding = DialogVolumeBoostBinding.inflate(getLayoutInflater());
+        initUI();
+
+        return new AlertDialog.Builder(requireActivity())
+                .setTitle(R.string.volume_boost)
+                .setView(binding.getRoot())
+                .setCancelable(true)
+                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> {
+                    setVolumeBoost(initialVolumeBoost);
+                    setAutoVolumeBoost(initialAutoVolumeBoost);
+                    updateCallback();
+                })
+                .setNeutralButton(R.string.playback_reset, (dialogInterface, i) -> {
+                    setVolumeBoost(MIN_VOLUME_BOOST);
+                    setAutoVolumeBoost(false);
+                    updateCallback();
+                })
+                .setPositiveButton(R.string.ok, (dialogInterface, i) -> updateCallback())
+                .create();
+    }
+
+    private void initUI() {
+        binding.volumeBoostMinimumText.setText(PlayerHelper.formatPitch(MIN_VOLUME_BOOST));
+        binding.volumeBoostMaximumText.setText(PlayerHelper.formatPitch(MAX_VOLUME_BOOST));
+        binding.volumeBoostStepDown.setText(getStepString(-VOLUME_BOOST_STEP));
+        binding.volumeBoostStepUp.setText(getStepString(VOLUME_BOOST_STEP));
+
+        binding.volumeBoostSeekbar.setMax(STRATEGY.progressOf(MAX_VOLUME_BOOST));
+        binding.volumeBoostSeekbar.setOnSeekBarChangeListener(
+                new SimpleOnSeekBarChangeListener() {
+                    @Override
+                    public void onProgressChanged(@NonNull final SeekBar seekBar,
+                                                  final int progress,
+                                                  final boolean fromUser) {
+                        if (fromUser) { // ensure that the user triggered the change
+                            setVolumeBoost(STRATEGY.valueOf(progress));
+                            updateCallback();
+                        }
+                    }
+                });
+
+        binding.volumeBoostStepDown.setOnClickListener(view -> {
+            setVolumeBoost(volumeBoost - VOLUME_BOOST_STEP);
+            updateCallback();
+        });
+        binding.volumeBoostStepUp.setOnClickListener(view -> {
+            setVolumeBoost(volumeBoost + VOLUME_BOOST_STEP);
+            updateCallback();
+        });
+
+        binding.autoVolumeBoostSwitch.setOnCheckedChangeListener((view, isChecked) -> {
+            setAutoVolumeBoost(isChecked);
+            updateCallback();
+        });
+
+        setVolumeBoost(volumeBoost);
+        setAutoVolumeBoost(autoVolumeBoost);
+    }
+
+    private void setVolumeBoost(final double newVolumeBoost) {
+        volumeBoost = MathUtils.clamp(newVolumeBoost, MIN_VOLUME_BOOST, MAX_VOLUME_BOOST);
+
+        binding.volumeBoostSeekbar.setProgress(STRATEGY.progressOf(volumeBoost));
+        binding.volumeBoostCurrentText.setText(PlayerHelper.formatPitch(volumeBoost));
+    }
+
+    private void setAutoVolumeBoost(final boolean newAutoVolumeBoost) {
+        autoVolumeBoost = newAutoVolumeBoost;
+
+        binding.autoVolumeBoostSwitch.setChecked(newAutoVolumeBoost);
+        // the gain is chosen by the player itself in automatic mode, so the slider does not apply
+        binding.volumeBoostSeekbar.setEnabled(!newAutoVolumeBoost);
+        binding.volumeBoostStepDown.setEnabled(!newAutoVolumeBoost);
+        binding.volumeBoostStepUp.setEnabled(!newAutoVolumeBoost);
+        setChildrenAlpha(newAutoVolumeBoost ? 0.4f : 1.0f);
+    }
+
+    private void setChildrenAlpha(final float alpha) {
+        for (final View view : new View[] {
+                binding.volumeBoostSeekbar,
+                binding.volumeBoostStepDown,
+                binding.volumeBoostStepUp,
+                binding.volumeBoostMinimumText,
+                binding.volumeBoostCurrentText,
+                binding.volumeBoostMaximumText
+        }) {
+            view.setAlpha(alpha);
+        }
+    }
+
+    private void updateCallback() {
+        if (callback != null) {
+            callback.onVolumeBoostChanged((float) volumeBoost, autoVolumeBoost);
+        }
+    }
+
+    @NonNull
+    private static String getStepString(final double step) {
+        return (step > 0 ? "+" : "-") + PlayerHelper.formatPitch(Math.abs(step));
+    }
+
+    public interface Callback {
+        void onVolumeBoostChanged(float volumeBoost, boolean autoVolumeBoost);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/helper/VolumeBoostRenderersFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/VolumeBoostRenderersFactory.java
@@ -1,0 +1,89 @@
+package org.schabi.newpipe.player.helper;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.DefaultRenderersFactory;
+import com.google.android.exoplayer2.audio.AudioProcessor;
+import com.google.android.exoplayer2.audio.AudioSink;
+import com.google.android.exoplayer2.audio.DefaultAudioSink;
+
+/**
+ * A {@link DefaultRenderersFactory} which adds a {@link VolumeBoostAudioProcessor} to the audio
+ * sink, so that the volume of quiet streams can be amplified beyond the system volume.
+ *
+ * <p>
+ * The audio sink is rebuilt every time a new player is created, therefore the currently wanted
+ * gain is kept here and forwarded to the audio processor which is in use at the moment.
+ * </p>
+ */
+public class VolumeBoostRenderersFactory extends DefaultRenderersFactory {
+
+    private float volumeBoost = VolumeBoostAudioProcessor.MINIMUM_VOLUME_BOOST;
+    private boolean automaticVolumeBoost = false;
+
+    @Nullable
+    private VolumeBoostAudioProcessor volumeBoostAudioProcessor;
+
+    public VolumeBoostRenderersFactory(@NonNull final Context context) {
+        super(context);
+    }
+
+    public float getVolumeBoost() {
+        return volumeBoost;
+    }
+
+    /**
+     * Applies the provided gain to the audio sink currently in use, if any, and remembers it so
+     * that audio sinks built later on also use it.
+     *
+     * @param newVolumeBoost the gain to apply to the decoded audio samples
+     */
+    public void setVolumeBoost(final float newVolumeBoost) {
+        volumeBoost = newVolumeBoost;
+        if (volumeBoostAudioProcessor != null) {
+            volumeBoostAudioProcessor.setVolumeBoost(newVolumeBoost);
+        }
+    }
+
+    public boolean isAutomaticVolumeBoost() {
+        return automaticVolumeBoost;
+    }
+
+    /**
+     * Enables or disables the automatic gain of the audio sink currently in use, if any, and
+     * remembers the choice so that audio sinks built later on also use it.
+     *
+     * @param newAutomaticVolumeBoost whether the gain should be computed from the loudness of the
+     *                                stream instead of being the one set by the user
+     */
+    public void setAutomaticVolumeBoost(final boolean newAutomaticVolumeBoost) {
+        automaticVolumeBoost = newAutomaticVolumeBoost;
+        if (volumeBoostAudioProcessor != null) {
+            volumeBoostAudioProcessor.setAutomaticVolumeBoost(newAutomaticVolumeBoost);
+        }
+    }
+
+    @Nullable
+    @Override
+    protected AudioSink buildAudioSink(@NonNull final Context context,
+                                       final boolean enableFloatOutput,
+                                       final boolean enableAudioTrackPlaybackParams,
+                                       final boolean enableOffload) {
+        // audio processors may not be shared between audio sinks, so build a new one every time
+        volumeBoostAudioProcessor = new VolumeBoostAudioProcessor();
+        volumeBoostAudioProcessor.setVolumeBoost(volumeBoost);
+        volumeBoostAudioProcessor.setAutomaticVolumeBoost(automaticVolumeBoost);
+
+        return new DefaultAudioSink.Builder(context)
+                .setAudioProcessors(new AudioProcessor[] {volumeBoostAudioProcessor})
+                .setEnableFloatOutput(enableFloatOutput)
+                .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                .setOffloadMode(enableOffload
+                        ? DefaultAudioSink.OFFLOAD_MODE_ENABLED_GAPLESS_REQUIRED
+                        : DefaultAudioSink.OFFLOAD_MODE_DISABLED)
+                .build();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -61,6 +61,7 @@ import org.schabi.newpipe.player.gesture.BasePlayerGestureListener;
 import org.schabi.newpipe.player.gesture.MainPlayerGestureListener;
 import org.schabi.newpipe.player.helper.PlaybackParameterDialog;
 import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.helper.VolumeBoostDialog;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueAdapter;
@@ -860,6 +861,14 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
                 PlaybackParameterDialog.newInstance(player.getPlaybackSpeed(),
                                 player.getPlaybackPitch(), player.getPlaybackSkipSilence(),
                                 player::setPlaybackParameters)
+                        .show(activity.getSupportFragmentManager(), null));
+    }
+
+    @Override
+    protected void onVolumeBoostClicked() {
+        getParentActivity().ifPresent(activity ->
+                VolumeBoostDialog.newInstance(player.getVolumeBoost(),
+                                player.isAutoVolumeBoostEnabled(), player::setVolumeBoost)
                         .show(activity.getSupportFragmentManager(), null));
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -169,6 +169,12 @@ public abstract class PlayerUi {
     }
 
     /**
+     * Called when the volume boost, or whether it is adjusted automatically, was changed.
+     */
+    public void onVolumeBoostChanged() {
+    }
+
+    /**
      * @see com.google.android.exoplayer2.Player.Listener#onRenderedFirstFrame
      */
     public void onRenderedFirstFrame() {

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
@@ -444,6 +444,14 @@ public final class PopupPlayerUi extends VideoPlayerUi {
         playbackSpeedPopupMenu.show();
         isSomePopupMenuVisible = true;
     }
+
+    @Override
+    protected void onVolumeBoostClicked() {
+        // the popup player has no activity to show a dialog on, so use a menu instead
+        buildVolumeBoostMenu();
+        volumeBoostPopupMenu.show();
+        isSomePopupMenuVisible = true;
+    }
     //endregion
 
 

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -17,6 +17,7 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.nextResizeModeAndSav
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
 
 import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -42,11 +43,13 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.AppCompatImageButton;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.BitmapCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.math.MathUtils;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.core.widget.ImageViewCompat;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlayer;
@@ -72,6 +75,7 @@ import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.gesture.BasePlayerGestureListener;
 import org.schabi.newpipe.player.gesture.DisplayPortion;
 import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.helper.VolumeBoostAudioProcessor;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.playback.SurfaceHolderCallback;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
@@ -102,6 +106,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
     // other constants (TODO remove playback speeds and use normal menu for popup, too)
     private static final float[] PLAYBACK_SPEEDS = {0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f};
+    private static final float[] VOLUME_BOOSTS = {1.0f, 1.25f, 1.5f, 2.0f, 2.5f, 3.0f};
 
     private enum PlayButtonAction {
         PLAY, PAUSE, REPLAY
@@ -126,11 +131,13 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     private static final int POPUP_MENU_ID_AUDIO_TRACK = 70;
     private static final int POPUP_MENU_ID_PLAYBACK_SPEED = 79;
     private static final int POPUP_MENU_ID_CAPTION = 89;
+    private static final int POPUP_MENU_ID_VOLUME_BOOST = 99;
 
     protected boolean isSomePopupMenuVisible = false;
     private PopupMenu qualityPopupMenu;
     private PopupMenu audioTrackPopupMenu;
     protected PopupMenu playbackSpeedPopupMenu;
+    protected PopupMenu volumeBoostPopupMenu;
     private PopupMenu captionPopupMenu;
 
 
@@ -183,6 +190,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         qualityPopupMenu = new PopupMenu(themeWrapper, binding.qualityTextView);
         audioTrackPopupMenu = new PopupMenu(themeWrapper, binding.audioTrackTextView);
         playbackSpeedPopupMenu = new PopupMenu(context, binding.playbackSpeed);
+        volumeBoostPopupMenu = new PopupMenu(themeWrapper, binding.volumeBoostButton);
         captionPopupMenu = new PopupMenu(themeWrapper, binding.captionTextView);
 
         binding.progressBarLoadingPanel.getIndeterminateDrawable()
@@ -202,6 +210,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.audioTrackTextView.setOnClickListener(
                 makeOnClickListener(this::onAudioTracksClicked));
         binding.playbackSpeed.setOnClickListener(makeOnClickListener(this::onPlaybackSpeedClicked));
+        binding.volumeBoostButton.setOnClickListener(
+                makeOnClickListener(this::onVolumeBoostClicked));
 
         binding.playbackSeekBar.setOnSeekBarChangeListener(this);
         binding.captionTextView.setOnClickListener(makeOnClickListener(this::onCaptionClicked));
@@ -279,6 +289,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.qualityTextView.setOnClickListener(null);
         binding.audioTrackTextView.setOnClickListener(null);
         binding.playbackSpeed.setOnClickListener(null);
+        binding.volumeBoostButton.setOnClickListener(null);
         binding.playbackSeekBar.setOnSeekBarChangeListener(null);
         binding.captionTextView.setOnClickListener(null);
         binding.resizeTextView.setOnClickListener(null);
@@ -798,6 +809,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         super.onPrepared();
         setVideoDurationToControls((int) player.getExoPlayer().getDuration());
         binding.playbackSpeed.setText(formatSpeed(player.getPlaybackSpeed()));
+        updateVolumeBoostButton();
     }
 
     @Override
@@ -1169,6 +1181,38 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         playbackSpeedPopupMenu.setOnDismissListener(this);
     }
 
+    /**
+     * Builds the volume boost menu shown by the players which can't show a dialog. The last entry
+     * is the automatic mode, all the others are fixed gains.
+     */
+    protected void buildVolumeBoostMenu() {
+        if (volumeBoostPopupMenu == null) {
+            return;
+        }
+        volumeBoostPopupMenu.getMenu().removeGroup(POPUP_MENU_ID_VOLUME_BOOST);
+
+        for (int i = 0; i < VOLUME_BOOSTS.length; i++) {
+            final CharSequence title = VOLUME_BOOSTS[i] == VolumeBoostAudioProcessor
+                    .MINIMUM_VOLUME_BOOST
+                    ? context.getString(R.string.volume_boost_off)
+                    : PlayerHelper.formatPitch(VOLUME_BOOSTS[i]);
+            volumeBoostPopupMenu.getMenu()
+                    .add(POPUP_MENU_ID_VOLUME_BOOST, i, Menu.NONE, title)
+                    .setCheckable(true)
+                    .setChecked(!player.isAutoVolumeBoostEnabled()
+                            && player.getVolumeBoost() == VOLUME_BOOSTS[i]);
+        }
+
+        volumeBoostPopupMenu.getMenu()
+                .add(POPUP_MENU_ID_VOLUME_BOOST, VOLUME_BOOSTS.length, Menu.NONE,
+                        R.string.volume_boost_auto)
+                .setCheckable(true)
+                .setChecked(player.isAutoVolumeBoostEnabled());
+
+        volumeBoostPopupMenu.setOnMenuItemClickListener(this);
+        volumeBoostPopupMenu.setOnDismissListener(this);
+    }
+
     private void buildCaptionMenu(@NonNull final List<String> availableLanguages) {
         if (captionPopupMenu == null) {
             return;
@@ -1253,6 +1297,27 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
     protected abstract void onPlaybackSpeedClicked();
 
+    protected abstract void onVolumeBoostClicked();
+
+    @Override
+    public void onVolumeBoostChanged() {
+        super.onVolumeBoostChanged();
+        updateVolumeBoostButton();
+    }
+
+    /**
+     * Highlights the volume boost button whenever the audio is being amplified, so that the user
+     * can tell at a glance that the stream is not being played back as it is.
+     */
+    private void updateVolumeBoostButton() {
+        final boolean boosting = player.isAutoVolumeBoostEnabled()
+                || player.getVolumeBoost() > VolumeBoostAudioProcessor.MINIMUM_VOLUME_BOOST;
+        ImageViewCompat.setImageTintList(binding.volumeBoostButton, ColorStateList.valueOf(
+                boosting
+                        ? ContextCompat.getColor(context, R.color.dark_settings_accent_color)
+                        : Color.WHITE));
+    }
+
     private void onQualityClicked() {
         qualityPopupMenu.show();
         isSomePopupMenuVisible = true;
@@ -1290,9 +1355,23 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
             player.setPlaybackSpeed(speed);
             binding.playbackSpeed.setText(formatSpeed(speed));
+        } else if (menuItem.getGroupId() == POPUP_MENU_ID_VOLUME_BOOST) {
+            onVolumeBoostItemClick(menuItem);
+            return true;
         }
 
         return false;
+    }
+
+    private void onVolumeBoostItemClick(@NonNull final MenuItem menuItem) {
+        final int menuItemIndex = menuItem.getItemId();
+        if (menuItemIndex == VOLUME_BOOSTS.length) {
+            // the last entry is the automatic mode, which keeps the last gain the user picked
+            player.setVolumeBoost(player.getVolumeBoost(), true);
+        } else {
+            player.setVolumeBoost(VOLUME_BOOSTS[menuItemIndex], false);
+        }
+        buildVolumeBoostMenu();
     }
 
     private void onQualityItemClick(@NonNull final MenuItem menuItem) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -44,7 +44,7 @@ public final class DeviceUtils {
      * support media tunneling to match the <strong>upcoming</strong> version code.</p>
      * @see #shouldSupportMediaTunneling()
      */
-    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 994;
+    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 1015;
 
     // region: devices not supporting media tunneling / media tunneling blacklist
     /**
@@ -120,6 +120,16 @@ public final class DeviceUtils {
      *     #10122</a></p>
      */
     private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    /**
+     * <p>JMGO N1S 4K.</p>
+     * <p>Blacklist reason: fullscreen crash</p>
+     */
+    private static final boolean LONAVLA = Build.DEVICE.equals("lonavla");
+    /**
+     * <p>TCL 65Q651G.</p>
+     * <p>Blacklist reason: fullscreen crash</p>
+     */
+    private static final boolean G10 = Build.DEVICE.equals("G10");
     // endregion
 
     private DeviceUtils() {
@@ -334,7 +344,9 @@ public final class DeviceUtils {
                 && !BRAVIA_ATV3_4K
                 && !PH7M_EU_5596
                 && !TX_50JXW834
-                && !HMB9213NW;
+                && !HMB9213NW
+                && !LONAVLA
+                && !G10;
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/SliderStrategy.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SliderStrategy.java
@@ -19,7 +19,43 @@ public interface SliderStrategy {
      */
     double valueOf(int progress);
 
-    // TODO: also implement linear strategy when needed
+    final class Linear implements SliderStrategy {
+        private final double minimum;
+        private final double range;
+
+        private final int maxProgress;
+
+        /**
+         * Linear slider strategy that maps the slider progress evenly onto the interpreted value,
+         * i.e. moving the slider by the same amount always changes the value by the same amount.
+         *
+         * @param minimum     the minimum value of the interpreted value of the slider.
+         * @param maximum     the maximum value of the interpreted value of the slider.
+         * @param maxProgress the maximum possible progress of the slider, this is the
+         *                    value that is shown for the UI and controls the granularity of
+         *                    the slider. Should be as large as possible to avoid floating
+         *                    point round-off error.
+         */
+        public Linear(final double minimum, final double maximum, final int maxProgress) {
+            if (maximum <= minimum) {
+                throw new IllegalArgumentException("Maximum must be greater than minimum");
+            }
+
+            this.minimum = minimum;
+            this.range = maximum - minimum;
+            this.maxProgress = maxProgress;
+        }
+
+        @Override
+        public int progressOf(final double value) {
+            return (int) Math.round((value - minimum) / range * maxProgress);
+        }
+
+        @Override
+        public double valueOf(final int progress) {
+            return minimum + ((double) progress) / ((double) maxProgress) * range;
+        }
+    }
 
     final class Quadratic implements SliderStrategy {
         private final double leftGap;

--- a/app/src/main/res/layout/dialog_volume_boost.xml
+++ b/app/src/main/res/layout/dialog_volume_boost.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="20dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="8dp">
+
+        <org.schabi.newpipe.views.NewPipeTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/volume_boost_summary"
+            android:textSize="14sp" />
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp">
+
+            <org.schabi.newpipe.views.NewPipeTextView
+                android:id="@+id/volumeBoostStepDown"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:text="-25%"
+                android:textColor="?attr/colorAccent"
+                android:textStyle="bold"
+                tools:ignore="HardcodedText" />
+
+            <org.schabi.newpipe.views.NewPipeTextView
+                android:id="@+id/volumeBoostStepUp"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:text="+25%"
+                android:textColor="?attr/colorAccent"
+                android:textStyle="bold"
+                tools:ignore="HardcodedText" />
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_toStartOf="@id/volumeBoostStepUp"
+                android:layout_toEndOf="@id/volumeBoostStepDown">
+
+                <org.schabi.newpipe.views.NewPipeTextView
+                    android:id="@+id/volumeBoostMinimumText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:gravity="center"
+                    android:text="100%"
+                    android:textColor="?attr/colorAccent"
+                    tools:ignore="HardcodedText" />
+
+                <org.schabi.newpipe.views.NewPipeTextView
+                    android:id="@+id/volumeBoostCurrentText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerHorizontal="true"
+                    android:gravity="center"
+                    android:text="100%"
+                    android:textColor="?attr/colorAccent"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <org.schabi.newpipe.views.NewPipeTextView
+                    android:id="@+id/volumeBoostMaximumText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:gravity="center"
+                    android:text="300%"
+                    android:textColor="?attr/colorAccent"
+                    tools:ignore="HardcodedText" />
+
+                <androidx.appcompat.widget.AppCompatSeekBar
+                    android:id="@+id/volumeBoostSeekbar"
+                    style="@style/Widget.AppCompat.SeekBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/volumeBoostCurrentText"
+                    tools:progress="0" />
+            </RelativeLayout>
+        </RelativeLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="?attr/separator_color" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/autoVolumeBoostSwitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/volume_boost_auto"
+            android:textStyle="bold" />
+
+        <org.schabi.newpipe.views.NewPipeTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/volume_boost_auto_summary"
+            android:textSize="13sp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -221,6 +221,21 @@
                         tools:text="1x" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/volumeBoostButton"
+                        android:layout_width="35dp"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:clickable="true"
+                        android:contentDescription="@string/volume_boost"
+                        android:focusable="true"
+                        android:padding="@dimen/player_main_buttons_padding"
+                        android:scaleType="fitCenter"
+                        android:src="@drawable/ic_volume_up"
+                        app:tint="@color/white"
+                        tools:ignore="RtlHardcoded" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/queueButton"
                         android:layout_width="35dp"
                         android:layout_height="35dp"

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -356,6 +356,8 @@
     <string name="playback_speed_key">playback_speed_key</string>
     <string name="playback_pitch_key">playback_pitch_key</string>
     <string name="playback_skip_silence_key">playback_skip_silence_key</string>
+    <string name="playback_volume_boost_key">playback_volume_boost_key</string>
+    <string name="playback_auto_volume_boost_key">playback_auto_volume_boost_key</string>
 
     <string name="app_language_key">app_language_key</string>
     <string name="app_language_android_13_and_up_key">app_language_android_13_and_up_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -543,6 +543,12 @@
     <string name="playback_speed_control">Playback Speed Controls</string>
     <string name="playback_tempo">Tempo</string>
     <string name="playback_pitch">Pitch</string>
+    <!-- Volume boost -->
+    <string name="volume_boost">Volume boost</string>
+    <string name="volume_boost_summary">Amplify quiet streams beyond the maximum system volume. Boosting a lot may cause distortion.</string>
+    <string name="volume_boost_auto">Adjust automatically</string>
+    <string name="volume_boost_auto_summary">Continuously measure how loud the stream is and amplify quiet parts in real time</string>
+    <string name="volume_boost_off">Off</string>
     <string name="unhook_checkbox">Unhook (may cause distortion)</string>
     <string name="skip_silence_checkbox">Fast-forward during silence</string>
     <string name="playback_step">Step</string>

--- a/app/src/test/java/org/schabi/newpipe/player/helper/VolumeBoostAudioProcessorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/VolumeBoostAudioProcessorTest.java
@@ -1,0 +1,240 @@
+package org.schabi.newpipe.player.helper;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.schabi.newpipe.player.helper.VolumeBoostAudioProcessor.MAXIMUM_VOLUME_BOOST;
+import static org.schabi.newpipe.player.helper.VolumeBoostAudioProcessor.MINIMUM_VOLUME_BOOST;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.audio.AudioProcessor;
+import com.google.android.exoplayer2.audio.AudioProcessor.AudioFormat;
+import com.google.android.exoplayer2.audio.AudioProcessor.UnhandledAudioFormatException;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class VolumeBoostAudioProcessorTest {
+
+    private static final int SAMPLE_RATE = 44100;
+    private static final int CHANNEL_COUNT = 2;
+
+    private static final AudioFormat PCM_16_BIT =
+            new AudioFormat(SAMPLE_RATE, CHANNEL_COUNT, C.ENCODING_PCM_16BIT);
+    private static final AudioFormat PCM_FLOAT =
+            new AudioFormat(SAMPLE_RATE, CHANNEL_COUNT, C.ENCODING_PCM_FLOAT);
+
+    private static final float FLOAT_TOLERANCE = 0.0001f;
+
+    private static VolumeBoostAudioProcessor processorFor(final AudioFormat audioFormat)
+            throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = new VolumeBoostAudioProcessor();
+        processor.configure(audioFormat);
+        // the configuration only takes effect once the processor is flushed, just like when it is
+        // used by an actual audio sink
+        processor.flush();
+        return processor;
+    }
+
+    private static ByteBuffer bufferOf(final short... samples) {
+        final ByteBuffer buffer = ByteBuffer
+                .allocateDirect(samples.length * 2)
+                .order(ByteOrder.nativeOrder());
+        for (final short sample : samples) {
+            buffer.putShort(sample);
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    private static ByteBuffer bufferOf(final float... samples) {
+        final ByteBuffer buffer = ByteBuffer
+                .allocateDirect(samples.length * 4)
+                .order(ByteOrder.nativeOrder());
+        for (final float sample : samples) {
+            buffer.putFloat(sample);
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    private static short[] shortsOf(final ByteBuffer buffer) {
+        final short[] samples = new short[buffer.remaining() / 2];
+        for (int i = 0; i < samples.length; i++) {
+            samples[i] = buffer.getShort(buffer.position() + i * 2);
+        }
+        return samples;
+    }
+
+    private static float[] floatsOf(final ByteBuffer buffer) {
+        final float[] samples = new float[buffer.remaining() / 4];
+        for (int i = 0; i < samples.length; i++) {
+            samples[i] = buffer.getFloat(buffer.position() + i * 4);
+        }
+        return samples;
+    }
+
+    /**
+     * Feeds a square wave, i.e. a signal whose loudness is exactly its amplitude, to the processor
+     * and returns the loudest sample it output while processing the last buffer.
+     *
+     * @param processor the processor to feed, which must be configured for float samples
+     * @param amplitude the amplitude of every sample of the signal
+     * @param seconds   how many seconds of audio to feed
+     * @return the absolute value of the loudest sample of the output of the last buffer
+     */
+    private static float feedSquareWave(final VolumeBoostAudioProcessor processor,
+                                       final float amplitude,
+                                       final float seconds) {
+        final int framesPerBuffer = 1024;
+        final int samplesPerBuffer = framesPerBuffer * CHANNEL_COUNT;
+        final int bufferCount = (int) (seconds * SAMPLE_RATE / framesPerBuffer);
+
+        final float[] samples = new float[samplesPerBuffer];
+        for (int i = 0; i < samples.length; i++) {
+            // alternate the sign every frame, so that the signal has no constant offset
+            samples[i] = (i / CHANNEL_COUNT) % 2 == 0 ? amplitude : -amplitude;
+        }
+
+        float peak = 0.0f;
+        for (int i = 0; i < bufferCount; i++) {
+            processor.queueInput(bufferOf(samples));
+
+            peak = 0.0f;
+            for (final float sample : floatsOf(processor.getOutput())) {
+                peak = Math.max(peak, Math.abs(sample));
+            }
+        }
+        return peak;
+    }
+
+    @Test
+    public void encodingsWhichCannotBeAmplifiedAreRejected() {
+        final VolumeBoostAudioProcessor processor = new VolumeBoostAudioProcessor();
+        assertThrows(UnhandledAudioFormatException.class, () -> processor.configure(
+                new AudioFormat(SAMPLE_RATE, CHANNEL_COUNT, C.ENCODING_AC3)));
+    }
+
+    @Test
+    public void volumeBoostIsClampedToTheAllowedRange() {
+        final VolumeBoostAudioProcessor processor = new VolumeBoostAudioProcessor();
+
+        processor.setVolumeBoost(100.0f);
+        assertEquals(MAXIMUM_VOLUME_BOOST, processor.getVolumeBoost(), FLOAT_TOLERANCE);
+
+        processor.setVolumeBoost(0.0f);
+        assertEquals(MINIMUM_VOLUME_BOOST, processor.getVolumeBoost(), FLOAT_TOLERANCE);
+    }
+
+    /**
+     * The audio pipeline hands over the shared empty buffer whenever there is nothing to process,
+     * which used to make the processor copy that buffer onto itself and throw, aborting playback
+     * before the first frame was even rendered.
+     */
+    @Test
+    public void emptyInputIsAccepted() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_16_BIT);
+
+        processor.queueInput(AudioProcessor.EMPTY_BUFFER);
+        assertFalse(processor.getOutput().hasRemaining());
+
+        processor.setVolumeBoost(2.0f);
+        processor.queueInput(AudioProcessor.EMPTY_BUFFER);
+        assertFalse(processor.getOutput().hasRemaining());
+
+        processor.setAutomaticVolumeBoost(true);
+        processor.queueInput(AudioProcessor.EMPTY_BUFFER);
+        assertFalse(processor.getOutput().hasRemaining());
+    }
+
+    @Test
+    public void samplesArePassedThroughWhenNotBoosting() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_16_BIT);
+        final short[] samples = {0, 123, -456, Short.MAX_VALUE, Short.MIN_VALUE};
+
+        processor.queueInput(bufferOf(samples));
+
+        assertArrayEquals(samples, shortsOf(processor.getOutput()));
+    }
+
+    @Test
+    public void pcm16BitSamplesAreAmplifiedAndClipped() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_16_BIT);
+        processor.setVolumeBoost(2.0f);
+
+        processor.queueInput(bufferOf((short) 0, (short) 100, (short) -100, (short) 20000,
+                (short) -20000));
+
+        assertArrayEquals(new short[] {0, 200, -200, Short.MAX_VALUE, Short.MIN_VALUE},
+                shortsOf(processor.getOutput()));
+    }
+
+    @Test
+    public void pcmFloatSamplesAreAmplifiedAndClipped() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_FLOAT);
+        processor.setVolumeBoost(2.0f);
+
+        processor.queueInput(bufferOf(0.0f, 0.1f, -0.1f, 0.6f, -0.6f));
+
+        assertArrayEquals(new float[] {0.0f, 0.2f, -0.2f, 1.0f, -1.0f},
+                floatsOf(processor.getOutput()), FLOAT_TOLERANCE);
+    }
+
+    @Test
+    public void theWholeInputBufferIsConsumed() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_16_BIT);
+        processor.setVolumeBoost(2.0f);
+
+        final ByteBuffer inputBuffer = bufferOf((short) 1, (short) 2, (short) 3);
+        processor.queueInput(inputBuffer);
+
+        assertFalse("the pipeline would keep feeding the same buffer forever",
+                inputBuffer.hasRemaining());
+    }
+
+    @Test
+    public void automaticModeAmplifiesQuietAudio() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_FLOAT);
+        processor.setAutomaticVolumeBoost(true);
+
+        final float amplitude = 0.02f;
+        final float peak = feedSquareWave(processor, amplitude, 3.0f);
+
+        assertTrue("quiet audio should have been amplified, but the peak went from "
+                + amplitude + " to " + peak, peak > amplitude * 2.0f);
+        assertTrue("the gain should never exceed the maximum volume boost, but the peak went from "
+                        + amplitude + " to " + peak,
+                peak <= amplitude * MAXIMUM_VOLUME_BOOST + FLOAT_TOLERANCE);
+    }
+
+    @Test
+    public void automaticModeLeavesLoudAudioAlone() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_FLOAT);
+        processor.setAutomaticVolumeBoost(true);
+
+        final float amplitude = 0.95f;
+        final float peak = feedSquareWave(processor, amplitude, 3.0f);
+
+        assertEquals("audio which is already loud should not have been amplified",
+                amplitude, peak, FLOAT_TOLERANCE);
+    }
+
+    @Test
+    public void automaticModeStartsOverAfterAFlush() throws UnhandledAudioFormatException {
+        final VolumeBoostAudioProcessor processor = processorFor(PCM_FLOAT);
+        processor.setAutomaticVolumeBoost(true);
+
+        final float amplitude = 0.02f;
+        feedSquareWave(processor, amplitude, 3.0f);
+        // seeking, or playing another stream, flushes the processor
+        processor.flush();
+
+        final float peak = feedSquareWave(processor, amplitude, 0.05f);
+        assertTrue("the gain should have been reset, but the peak went from "
+                + amplitude + " to " + peak, peak < amplitude * 1.5f);
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/LinearSliderStrategyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/LinearSliderStrategyTest.java
@@ -1,0 +1,56 @@
+package org.schabi.newpipe.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LinearSliderStrategyTest {
+    private static final int STEP = 100;
+    private static final float DELTA = 1f / (float) STEP;
+
+    private final SliderStrategy.Linear standard =
+            new SliderStrategy.Linear(1f, 3f, STEP);
+
+    @Test
+    public void testLeftBound() {
+        assertEquals(0, standard.progressOf(1f));
+        assertEquals(1f, standard.valueOf(0), DELTA);
+    }
+
+    @Test
+    public void testCenter() {
+        assertEquals(50, standard.progressOf(2f));
+        assertEquals(2f, standard.valueOf(50), DELTA);
+    }
+
+    @Test
+    public void testRightBound() {
+        assertEquals(100, standard.progressOf(3f));
+        assertEquals(3f, standard.valueOf(100), DELTA);
+    }
+
+    @Test
+    public void testLinearProperty() {
+        final double lowerDifference = Math.abs(standard.valueOf(10) - standard.valueOf(20));
+        final double upperDifference = Math.abs(standard.valueOf(80) - standard.valueOf(90));
+        assertEquals(lowerDifference, upperDifference, DELTA);
+    }
+
+    @Test
+    public void testConversion() {
+        assertEquals(0, standard.progressOf(standard.valueOf(0)));
+        assertEquals(25, standard.progressOf(standard.valueOf(25)));
+        assertEquals(50, standard.progressOf(standard.valueOf(50)));
+        assertEquals(75, standard.progressOf(standard.valueOf(75)));
+        assertEquals(100, standard.progressOf(standard.valueOf(100)));
+    }
+
+    @Test
+    public void testReverseConversion() {
+        assertEquals(1.00f, standard.valueOf(standard.progressOf(1.00f)), DELTA);
+        assertEquals(1.50f, standard.valueOf(standard.progressOf(1.50f)), DELTA);
+        assertEquals(2.00f, standard.valueOf(standard.progressOf(2.00f)), DELTA);
+        assertEquals(2.50f, standard.valueOf(standard.progressOf(2.50f)), DELTA);
+        assertEquals(3.00f, standard.valueOf(standard.progressOf(3.00f)), DELTA);
+    }
+}


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Some streams are mastered so quietly that they are hard to hear even at the maximum
system volume. This adds a volume boost which amplifies the decoded PCM samples before
they reach the audio track, either with a gain the user picks or with one the player
derives from the stream in real time.

A new speaker button in the player control bar opens a dialog with a 100%–300%
slider and an "Adjust automatically" switch (off by default). The popup player
has no activity to host a dialog, so it gets a menu of gains instead.
VolumeBoostAudioProcessor amplifies 16 bit and float PCM, clipping whatever exceeds
the range of the encoding (the same trade-off VLC makes for its own volume boost).
In automatic mode it measures the loudness (RMS) and the peak of every buffer, aims
for roughly -16 dBFS, caps the gain so the peak stays below full scale, and smooths
the gain with a fast attack (50 ms) and a slow release (2 s), so a sudden loud passage
does not clip and a quiet one does not pump. It only ever amplifies, never attenuates,
and resets when the processor is flushed (seek, next stream).
VolumeBoostRenderersFactory installs the processor into the audio sink and keeps the
wanted gain across the sinks that are rebuilt every time a player is created.
CustomRenderersFactory now extends it, so both factories the player picks from
support the boost.
The button is tinted while the audio is being amplified, so it is visible at a glance
that the stream is not played back as it is.
The gain and the automatic mode are persisted in the preferences and restored on the
next playback, like the playback speed already is.
The audio processors ExoPlayer adds itself are kept, so playback speed, pitch and
silence skipping keep working alongside the boost.
Unit tests were added for the processor (amplification and clipping for both encodings,
empty input, clamping, and the automatic mode amplifying quiet audio, leaving loud audio
alone and resetting on flush) and for the new SliderStrategy.Linear.

#### Fixes the following issue(s)
- Fixes

#### Relies on the following changes

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [ ] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [ ] I tested the changes using an emulator or a physical device.
